### PR TITLE
add upcall flow limit

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -52,6 +52,12 @@ type ovsDPCollector struct {
 	docaResizeBlockMetric            *prometheus.Desc
 	docaPipeResizeMetric             *prometheus.Desc
 	docaPipeResizeOver10MsMetric     *prometheus.Desc
+	// Upcall Flow Limit
+	UpcallFlowLimitGrewMetric    *prometheus.Desc
+	UpcallFlowLimitHitMetric     *prometheus.Desc
+	UpcallFlowLimitKillMetric    *prometheus.Desc
+	UpcallFlowLimitReducedMetric *prometheus.Desc
+	UpcallFlowLimitScaledMetric  *prometheus.Desc
 }
 
 func isValidMetric(value float64) bool {
@@ -234,6 +240,27 @@ func newOvsDPCollector() *ovsDPCollector {
 		),
 		docaPipeResizeOver10MsMetric: prometheus.NewDesc("ovsdp_doca_pipe_resize_over_10_ms",
 			"Number of times a pipe resize operation takes longer than 10ms",
+			nil, nil,
+		),
+		// Upcall Flow Limit
+		UpcallFlowLimitGrewMetric: prometheus.NewDesc("ovsdp_upcall_flow_limit_grew",
+			"Number of times the flow_limit increased due to fast processing time",
+			nil, nil,
+		),
+		UpcallFlowLimitHitMetric: prometheus.NewDesc("ovsdp_upcall_flow_limit_hit",
+			"Number of times the flow_limit was hit during upcall processing",
+			nil, nil,
+		),
+		UpcallFlowLimitKillMetric: prometheus.NewDesc("ovsdp_upcall_flow_limit_kill",
+			"Number of times flows were killed due to exceeding flow_limit",
+			nil, nil,
+		),
+		UpcallFlowLimitReducedMetric: prometheus.NewDesc("ovsdp_upcall_flow_limit_reduced",
+			"Number of times the flow_limit was reduced due to high processing time",
+			nil, nil,
+		),
+		UpcallFlowLimitScaledMetric: prometheus.NewDesc("ovsdp_upcall_flow_limit_scaled",
+			"Number of times the flow_limit was scaled down proportionally due to very long processing time",
 			nil, nil,
 		),
 	}

--- a/metric.go
+++ b/metric.go
@@ -55,6 +55,12 @@ type OvsMetric struct {
 	DocaResizeBlock            float64
 	DocaPipeResize             float64
 	DocaPipeResizeOver10Ms     float64
+	// Upcall Flow Limit
+	UpcallFlowLimitGrew    float64
+	UpcallFlowLimitHit     float64
+	UpcallFlowLimitKill    float64
+	UpcallFlowLimitReduced float64
+	UpcallFlowLimitScaled  float64
 }
 
 func getOvsMetric() *OvsMetric {
@@ -496,6 +502,63 @@ func parseCoverageDropReasons(metrics *OvsMetric, coverageStats string) {
 			metrics.DatapathDropHwMissRecover = v
 		}
 	}
+
+	// Upcall Flow Limit
+	// upcall_flow_limit_grew
+	upcallFlowLimitGrewRegexp := regexp.MustCompile(`(?m)^[ \t]*upcall_flow_limit_grew.*total:\s*(\d+)`)
+	upcallFlowLimitGrewMatch := upcallFlowLimitGrewRegexp.FindStringSubmatch(coverageStats)
+	metrics.UpcallFlowLimitGrew = -1
+	if len(upcallFlowLimitGrewMatch) > 1 {
+		v, err := strconv.ParseFloat(upcallFlowLimitGrewMatch[1], 64)
+		if err == nil {
+			metrics.UpcallFlowLimitGrew = v
+		}
+	}
+
+	// upcall_flow_limit_hit
+	upcallFlowLimitHitRegexp := regexp.MustCompile(`(?m)^[ \t]*upcall_flow_limit_hit.*total:\s*(\d+)`)
+	upcallFlowLimitHitMatch := upcallFlowLimitHitRegexp.FindStringSubmatch(coverageStats)
+	metrics.UpcallFlowLimitHit = -1
+	if len(upcallFlowLimitHitMatch) > 1 {
+		v, err := strconv.ParseFloat(upcallFlowLimitHitMatch[1], 64)
+		if err == nil {
+			metrics.UpcallFlowLimitHit = v
+		}
+	}
+
+	// upcall_flow_limit_kill
+	upcallFlowLimitKillRegexp := regexp.MustCompile(`(?m)^[ \t]*upcall_flow_limit_kill.*total:\s*(\d+)`)
+	upcallFlowLimitKillMatch := upcallFlowLimitKillRegexp.FindStringSubmatch(coverageStats)
+	metrics.UpcallFlowLimitKill = -1
+	if len(upcallFlowLimitKillMatch) > 1 {
+		v, err := strconv.ParseFloat(upcallFlowLimitKillMatch[1], 64)
+		if err == nil {
+			metrics.UpcallFlowLimitKill = v
+		}
+	}
+
+	// upcall_flow_limit_reduced
+	upcallFlowLimitReducedRegexp := regexp.MustCompile(`(?m)^[ \t]*upcall_flow_limit_reduced.*total:\s*(\d+)`)
+	upcallFlowLimitReducedMatch := upcallFlowLimitReducedRegexp.FindStringSubmatch(coverageStats)
+	metrics.UpcallFlowLimitReduced = -1
+	if len(upcallFlowLimitReducedMatch) > 1 {
+		v, err := strconv.ParseFloat(upcallFlowLimitReducedMatch[1], 64)
+		if err == nil {
+			metrics.UpcallFlowLimitReduced = v
+		}
+	}
+
+	// upcall_flow_limit_scaled
+	upcallFlowLimitScaledRegexp := regexp.MustCompile(`(?m)^[ \t]*upcall_flow_limit_scaled.*total:\s*(\d+)`)
+	upcallFlowLimitScaledMatch := upcallFlowLimitScaledRegexp.FindStringSubmatch(coverageStats)
+	metrics.UpcallFlowLimitScaled = -1
+	if len(upcallFlowLimitScaledMatch) > 1 {
+		v, err := strconv.ParseFloat(upcallFlowLimitScaledMatch[1], 64)
+		if err == nil {
+			metrics.UpcallFlowLimitScaled = v
+		}
+	}
+
 }
 
 func parsePMDStats(metrics *OvsMetric, pmdStats string) {

--- a/metric_test.go
+++ b/metric_test.go
@@ -88,7 +88,12 @@ netdev_push_header_drops   0.0/sec     0.000/sec        0.0000/sec   total: 31
 netdev_soft_seg_drops   0.0/sec     0.000/sec        0.0000/sec   total: 32
 datapath_drop_tunnel_tso_recirc   0.0/sec     0.000/sec        0.0000/sec   total: 33
 datapath_drop_invalid_bond   0.0/sec     0.000/sec        0.0000/sec   total: 34
-datapath_drop_hw_miss_recover   0.0/sec     0.000/sec        0.0000/sec   total: 35`,
+datapath_drop_hw_miss_recover   0.0/sec     0.000/sec        0.0000/sec   total: 35
+upcall_flow_limit_grew       0.0/sec     0.000/sec        0.0000/sec   total: 36
+upcall_flow_limit_hit        0.0/sec     0.000/sec        0.0000/sec   total: 37
+upcall_flow_limit_kill       0.0/sec     0.000/sec        0.0000/sec   total: 38
+upcall_flow_limit_reduced    0.0/sec     0.000/sec        0.0000/sec   total: 39
+upcall_flow_limit_scaled     0.0/sec     0.000/sec        0.0000/sec   total: 40`,
 			metric: OvsMetric{
 				// Drop reasons
 				UpcallDrops:                      5,
@@ -123,6 +128,12 @@ datapath_drop_hw_miss_recover   0.0/sec     0.000/sec        0.0000/sec   total:
 				DatapathDropTunnelTsoRecirc: 33,
 				DatapathDropInvalidBond:     34,
 				DatapathDropHwMissRecover:   35,
+				// Upcall Flow Limit
+				UpcallFlowLimitGrew:    36,
+				UpcallFlowLimitHit:     37,
+				UpcallFlowLimitKill:    38,
+				UpcallFlowLimitReduced: 39,
+				UpcallFlowLimitScaled:  40,
 			},
 		},
 	}


### PR DESCRIPTION
## Summary

Add support for tracking OVS upcall flow limit metrics in the datapath exporter.

This PR introduces five new Prometheus metrics related to upcall flow limit dynamics:

- `ovsdp_upcall_flow_limit_grew`
- `ovsdp_upcall_flow_limit_hit`
- `ovsdp_upcall_flow_limit_kill`
- `ovsdp_upcall_flow_limit_reduced`
- `ovsdp_upcall_flow_limit_scaled`

These metrics help monitor and debug dynamic flow limit behavior during upcall handling in the OVS datapath. Each metric is:

- Exposed as a Prometheus descriptor in `exporter.go`
- Parsed from `coverage_stats` output in `metric.go` using a dedicated regex
- Covered by a unit test in `metric_test.go` with realistic mock data

All additions are non-breaking and maintain consistency with existing metric handling patterns.