### PR TITLE
Add offload-stats and memory/show parsing; expose metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,98 @@
-# ovsdp-exporter
-OVS datapath metric exporter
+### ovsdp-exporter
+OVS datapath metric exporter. It executes a few `ovs-appctl` commands and exposes selected values as Prometheus metrics.
+
+### Commands executed and exported metrics
+
+#### `ovs-appctl dpif-netdev/pmd-stats-show`
+PMD thread and datapath performance stats.
+
+- `ovsdp_miss_with_success_upcall`: Cache misses with successful upcalls.
+- `ovsdp_miss_with_failed_upcall`: Cache misses with failed upcalls.
+- `ovsdp_processing_cycles`: CPU cycles spent actively processing packets (percent).
+- `ovsdp_idle_cycles`: CPU cycles idle waiting for packets (percent).
+- `ovsdp_avg_subtable_lookups_megaflow`: Average subtable lookups per megaflow hit.
+
+#### `ovs-appctl dpctl/offload-stats-show`
+Hardware offload statistics and latency.
+
+- `ovsdp_offload_enqueued`: Enqueued offloads total.
+- `ovsdp_offload_inserted`: Inserted offloads total.
+- `ovsdp_offload_ct_unidir_connections`: CT uni-dir connections offloaded.
+- `ovsdp_offload_ct_bidir_connections`: CT bi-dir connections offloaded.
+- `ovsdp_offload_cum_avg_latency_us`: Cumulative average latency (microseconds).
+- `ovsdp_offload_cum_latency_stddev_us`: Cumulative latency standard deviation (microseconds).
+- `ovsdp_offload_cum_latency_max_us`: Cumulative latency maximum observed (microseconds).
+- `ovsdp_offload_cum_latency_min_us`: Cumulative latency minimum observed (microseconds).
+- `ovsdp_offload_exp_avg_latency_us`: Exponential moving average latency (microseconds).
+- `ovsdp_offload_exp_latency_stddev_us`: Exponential moving latency standard deviation (microseconds).
+
+#### `ovs-appctl coverage/show`
+Drop reasons, DOCA counters, and upcall flow-limit behavior.
+
+- Drop reasons (datapath and actions):
+  - `ovsdp_datapath_drop_upcall_error`: Drop due to error in the Upcall process.
+  - `ovsdp_datapath_drop_lock_error`: Drop due to Upcall lock contention.
+  - `ovsdp_datapath_drop_rx_invalid_packet`: Drop invalid packet (shorter than Ethernet header indicates).
+  - `ovsdp_datapath_drop_meter`: Drop in the OpenFlow Meter Table.
+  - `ovsdp_datapath_drop_userspace_action_error`: Drop due to generic action execution error.
+  - `ovsdp_datapath_drop_tunnel_push_error`: Drop due to tunnel push (encap) error.
+  - `ovsdp_datapath_drop_tunnel_pop_error`: Drop due to tunnel pop (decap) error.
+  - `ovsdp_datapath_drop_recirc_error`: Drop due to recirculation error.
+  - `ovsdp_datapath_drop_invalid_port`: Drop due to invalid port.
+  - `ovsdp_datapath_drop_invalid_tnl_port`: Drop due to invalid tunnel port on pop.
+  - `ovsdp_datapath_drop_sample_error`: Drop due to sampling error.
+  - `ovsdp_datapath_drop_nsh_decap_error`: Drop due to invalid NSH decapsulation.
+  - `ovsdp_drop_action_of_pipeline`: Drop due to pipeline/action parsing errors.
+  - `ovsdp_drop_action_bridge_not_found`: Drop due to bridge not found at translation time.
+  - `ovsdp_drop_action_recursion_too_deep`: Drop due to excessive translation recursion.
+  - `ovsdp_drop_action_too_many_resubmit`: Drop due to too many resubmits.
+  - `ovsdp_drop_action_stack_too_deep`: Drop due to excessive stack usage (>64kB).
+  - `ovsdp_drop_action_no_recirculation_context`: Drop due to missing recirculation context.
+  - `ovsdp_drop_action_recirculation_conflict`: Drop due to recirculation conflict.
+  - `ovsdp_drop_action_too_many_mpls_labels`: Drop due to too many MPLS labels to pop.
+  - `ovsdp_drop_action_invalid_tunnel_metadata`: Drop due to invalid GENEVE tunnel metadata.
+  - `ovsdp_drop_action_unsupported_packet_type`: Drop due to unsupported packet type.
+  - `ovsdp_drop_action_congestion`: Drop due to ECN congestion mismatch.
+  - `ovsdp_drop_action_forwarding_disabled`: Drop when port forwarding is disabled.
+
+- Additional datapath counters:
+  - `ovsdp_netdev_vxlan_tso_drops`: Drops due to VXLAN TSO issues.
+  - `ovsdp_netdev_geneve_tso_drops`: Drops due to Geneve TSO issues.
+  - `ovsdp_netdev_push_header_drops`: Drops due to push header errors.
+  - `ovsdp_netdev_soft_seg_drops`: Drops due to software segmentation issues.
+  - `ovsdp_datapath_drop_tunnel_tso_recirc`: Drops due to tunnel TSO recirculation errors.
+  - `ovsdp_datapath_drop_invalid_bond`: Drops due to invalid bond configuration.
+  - `ovsdp_datapath_drop_hw_miss_recover`: Drops due to hardware miss recovery failure.
+
+- DOCA:
+  - `ovsdp_ovs_doca_no_mark`: Packets dropped due to missing mark in OVS-DOCA.
+  - `ovsdp_ovs_doca_invalid_classify_port`: Packets dropped due to invalid classify port in OVS-DOCA.
+  - `ovsdp_doca_queue_empty`: Times an offload completion queue was found empty.
+  - `ovsdp_doca_queue_none_processed`: Times a queue had pending entries but none processed.
+  - `ovsdp_doca_resize_block`: Queue processing blocked during pipeline resizing with no entries processed.
+  - `ovsdp_doca_pipe_resize`: Times a pipe resize operation began.
+  - `ovsdp_doca_pipe_resize_over_10_ms`: Times a pipe resize took longer than 10 ms.
+
+- Upcall Flow Limit behavior:
+  - `ovsdp_upcall_flow_limit_grew`: Flow limit increased due to fast processing.
+  - `ovsdp_upcall_flow_limit_hit`: Flow limit was hit during upcall processing.
+  - `ovsdp_upcall_flow_limit_kill`: Flows killed due to exceeding flow limit.
+  - `ovsdp_upcall_flow_limit_reduced`: Flow limit reduced due to high processing time.
+  - `ovsdp_upcall_flow_limit_scaled`: Flow limit scaled down due to very long processing time.
+
+#### `ovs-appctl memory/show`
+High-level memory and thread/connection counts.
+
+- `ovsdp_memory_handlers`: Number of OVS handler threads handling OpenFlow connections and upcalls.
+- `ovsdp_memory_idl_cells_open_vswitch`: OVSDB cells in use for `Open_vSwitch` table (transaction/monitor memory).
+- `ovsdp_memory_ofconns`: Active OpenFlow controller connections.
+- `ovsdp_memory_ports`: Configured datapath ports (physical, virtual, and internal).
+- `ovsdp_memory_revalidators`: Revalidator threads that periodically revalidate userspace datapath flows.
+- `ovsdp_memory_rules`: Installed OpenFlow rules (software and hardware offloaded).
+- `ovsdp_memory_udpif_keys`: Unique userspace datapath (udpif) flow keys handled in software.
+
+### Running
+
+- Build: `go build .`
+- Run exporter: `./ovsdp-exporter -metrics.host :9000 -metrics.pathname /metrics`
+- Scrape: visit `http://<host>:9000/metrics`

--- a/exporter.go
+++ b/exporter.go
@@ -11,6 +11,14 @@ type ovsDPCollector struct {
 	avgSubtableLookupsMegaflowMetric *prometheus.Desc
 	processingCyclesMetric           *prometheus.Desc
 	idleCyclesMetric                 *prometheus.Desc
+	// Memory/show stats
+	memoryHandlersMetric            *prometheus.Desc
+	memoryIdlCellsOpenVSwitchMetric *prometheus.Desc
+	memoryOfconnsMetric             *prometheus.Desc
+	memoryPortsMetric               *prometheus.Desc
+	memoryRevalidatorsMetric        *prometheus.Desc
+	memoryRulesMetric               *prometheus.Desc
+	memoryUdpifKeysMetric           *prometheus.Desc
 	// Offload stats
 	offloadEnqueuedMetric           *prometheus.Desc
 	offloadInsertedMetric           *prometheus.Desc
@@ -96,6 +104,35 @@ func newOvsDPCollector() *ovsDPCollector {
 		),
 		avgSubtableLookupsMegaflowMetric: prometheus.NewDesc("ovsdp_avg_subtable_lookups_megaflow",
 			"Average of subtable lookups per megaflow hit",
+			nil, nil,
+		),
+		// Memory/show stats
+		memoryHandlersMetric: prometheus.NewDesc("ovsdp_memory_handlers",
+			"Number of OVS handler threads handling OpenFlow connections and upcalls",
+			nil, nil,
+		),
+		memoryIdlCellsOpenVSwitchMetric: prometheus.NewDesc("ovsdp_memory_idl_cells_open_vswitch",
+			"OVSDB cells in use for Open_vSwitch table (transaction/monitor memory)",
+			nil, nil,
+		),
+		memoryOfconnsMetric: prometheus.NewDesc("ovsdp_memory_ofconns",
+			"Active OpenFlow controller connections",
+			nil, nil,
+		),
+		memoryPortsMetric: prometheus.NewDesc("ovsdp_memory_ports",
+			"Configured datapath ports (physical, virtual, and internal)",
+			nil, nil,
+		),
+		memoryRevalidatorsMetric: prometheus.NewDesc("ovsdp_memory_revalidators",
+			"Revalidator threads that periodically revalidate userspace datapath flows",
+			nil, nil,
+		),
+		memoryRulesMetric: prometheus.NewDesc("ovsdp_memory_rules",
+			"Installed OpenFlow rules (software and hardware offloaded)",
+			nil, nil,
+		),
+		memoryUdpifKeysMetric: prometheus.NewDesc("ovsdp_memory_udpif_keys",
+			"Unique userspace datapath (udpif) flow keys handled in software",
 			nil, nil,
 		),
 		// Offload stats
@@ -326,6 +363,14 @@ func (collector *ovsDPCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- collector.idleCyclesMetric
 	ch <- collector.avgSubtableLookupsMegaflowMetric
 	ch <- collector.dropActionOfPipelineMetric
+	// Memory/show stats
+	ch <- collector.memoryHandlersMetric
+	ch <- collector.memoryIdlCellsOpenVSwitchMetric
+	ch <- collector.memoryOfconnsMetric
+	ch <- collector.memoryPortsMetric
+	ch <- collector.memoryRevalidatorsMetric
+	ch <- collector.memoryRulesMetric
+	ch <- collector.memoryUdpifKeysMetric
 	// Offload stats
 	ch <- collector.offloadEnqueuedMetric
 	ch <- collector.offloadInsertedMetric
@@ -403,6 +448,28 @@ func (collector *ovsDPCollector) Collect(ch chan<- prometheus.Metric) {
 	}
 	if isValidMetric(ovsMetric.AvgSubtableLookupsMegaflow) {
 		ch <- prometheus.MustNewConstMetric(collector.avgSubtableLookupsMegaflowMetric, prometheus.CounterValue, float64(ovsMetric.AvgSubtableLookupsMegaflow))
+	}
+	// Memory/show stats
+	if isValidMetric(ovsMetric.MemoryHandlers) {
+		ch <- prometheus.MustNewConstMetric(collector.memoryHandlersMetric, prometheus.GaugeValue, float64(ovsMetric.MemoryHandlers))
+	}
+	if isValidMetric(ovsMetric.MemoryIdlCellsOpenVSwitch) {
+		ch <- prometheus.MustNewConstMetric(collector.memoryIdlCellsOpenVSwitchMetric, prometheus.GaugeValue, float64(ovsMetric.MemoryIdlCellsOpenVSwitch))
+	}
+	if isValidMetric(ovsMetric.MemoryOfconns) {
+		ch <- prometheus.MustNewConstMetric(collector.memoryOfconnsMetric, prometheus.GaugeValue, float64(ovsMetric.MemoryOfconns))
+	}
+	if isValidMetric(ovsMetric.MemoryPorts) {
+		ch <- prometheus.MustNewConstMetric(collector.memoryPortsMetric, prometheus.GaugeValue, float64(ovsMetric.MemoryPorts))
+	}
+	if isValidMetric(ovsMetric.MemoryRevalidators) {
+		ch <- prometheus.MustNewConstMetric(collector.memoryRevalidatorsMetric, prometheus.GaugeValue, float64(ovsMetric.MemoryRevalidators))
+	}
+	if isValidMetric(ovsMetric.MemoryRules) {
+		ch <- prometheus.MustNewConstMetric(collector.memoryRulesMetric, prometheus.GaugeValue, float64(ovsMetric.MemoryRules))
+	}
+	if isValidMetric(ovsMetric.MemoryUdpifKeys) {
+		ch <- prometheus.MustNewConstMetric(collector.memoryUdpifKeysMetric, prometheus.GaugeValue, float64(ovsMetric.MemoryUdpifKeys))
 	}
 	// Offload stats
 	if isValidMetric(ovsMetric.OffloadEnqueued) {

--- a/exporter.go
+++ b/exporter.go
@@ -11,6 +11,17 @@ type ovsDPCollector struct {
 	avgSubtableLookupsMegaflowMetric *prometheus.Desc
 	processingCyclesMetric           *prometheus.Desc
 	idleCyclesMetric                 *prometheus.Desc
+	// Offload stats
+	offloadEnqueuedMetric           *prometheus.Desc
+	offloadInsertedMetric           *prometheus.Desc
+	offloadCtUniDirConnMetric       *prometheus.Desc
+	offloadCtBiDirConnMetric        *prometheus.Desc
+	offloadCumAvgLatencyUsMetric    *prometheus.Desc
+	offloadCumLatencyStddevUsMetric *prometheus.Desc
+	offloadCumLatencyMaxUsMetric    *prometheus.Desc
+	offloadCumLatencyMinUsMetric    *prometheus.Desc
+	offloadExpAvgLatencyUsMetric    *prometheus.Desc
+	offloadExpLatencyStddevUsMetric *prometheus.Desc
 	// Drop reasons
 	upcallDropsMetric                      *prometheus.Desc
 	upcallDropsLockErrorMetric             *prometheus.Desc
@@ -85,6 +96,47 @@ func newOvsDPCollector() *ovsDPCollector {
 		),
 		avgSubtableLookupsMegaflowMetric: prometheus.NewDesc("ovsdp_avg_subtable_lookups_megaflow",
 			"Average of subtable lookups per megaflow hit",
+			nil, nil,
+		),
+		// Offload stats
+		offloadEnqueuedMetric: prometheus.NewDesc("ovsdp_offload_enqueued",
+			"Enqueued offloads total",
+			nil, nil,
+		),
+		offloadInsertedMetric: prometheus.NewDesc("ovsdp_offload_inserted",
+			"Inserted offloads total",
+			nil, nil,
+		),
+		offloadCtUniDirConnMetric: prometheus.NewDesc("ovsdp_offload_ct_unidir_connections",
+			"CT uni-dir connections offloaded",
+			nil, nil,
+		),
+		offloadCtBiDirConnMetric: prometheus.NewDesc("ovsdp_offload_ct_bidir_connections",
+			"CT bi-dir connections offloaded",
+			nil, nil,
+		),
+		offloadCumAvgLatencyUsMetric: prometheus.NewDesc("ovsdp_offload_cum_avg_latency_us",
+			"Cumulative average latency (us)",
+			nil, nil,
+		),
+		offloadCumLatencyStddevUsMetric: prometheus.NewDesc("ovsdp_offload_cum_latency_stddev_us",
+			"Cumulative latency stddev (us)",
+			nil, nil,
+		),
+		offloadCumLatencyMaxUsMetric: prometheus.NewDesc("ovsdp_offload_cum_latency_max_us",
+			"Cumulative latency max (us)",
+			nil, nil,
+		),
+		offloadCumLatencyMinUsMetric: prometheus.NewDesc("ovsdp_offload_cum_latency_min_us",
+			"Cumulative latency min (us)",
+			nil, nil,
+		),
+		offloadExpAvgLatencyUsMetric: prometheus.NewDesc("ovsdp_offload_exp_avg_latency_us",
+			"Exponential average latency (us)",
+			nil, nil,
+		),
+		offloadExpLatencyStddevUsMetric: prometheus.NewDesc("ovsdp_offload_exp_latency_stddev_us",
+			"Exponential latency stddev (us)",
 			nil, nil,
 		),
 		// Drop reasons
@@ -274,6 +326,17 @@ func (collector *ovsDPCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- collector.idleCyclesMetric
 	ch <- collector.avgSubtableLookupsMegaflowMetric
 	ch <- collector.dropActionOfPipelineMetric
+	// Offload stats
+	ch <- collector.offloadEnqueuedMetric
+	ch <- collector.offloadInsertedMetric
+	ch <- collector.offloadCtUniDirConnMetric
+	ch <- collector.offloadCtBiDirConnMetric
+	ch <- collector.offloadCumAvgLatencyUsMetric
+	ch <- collector.offloadCumLatencyStddevUsMetric
+	ch <- collector.offloadCumLatencyMaxUsMetric
+	ch <- collector.offloadCumLatencyMinUsMetric
+	ch <- collector.offloadExpAvgLatencyUsMetric
+	ch <- collector.offloadExpLatencyStddevUsMetric
 	// Drop reasons
 	ch <- collector.upcallDropsMetric
 	ch <- collector.upcallDropsLockErrorMetric
@@ -340,6 +403,37 @@ func (collector *ovsDPCollector) Collect(ch chan<- prometheus.Metric) {
 	}
 	if isValidMetric(ovsMetric.AvgSubtableLookupsMegaflow) {
 		ch <- prometheus.MustNewConstMetric(collector.avgSubtableLookupsMegaflowMetric, prometheus.CounterValue, float64(ovsMetric.AvgSubtableLookupsMegaflow))
+	}
+	// Offload stats
+	if isValidMetric(ovsMetric.OffloadEnqueued) {
+		ch <- prometheus.MustNewConstMetric(collector.offloadEnqueuedMetric, prometheus.CounterValue, float64(ovsMetric.OffloadEnqueued))
+	}
+	if isValidMetric(ovsMetric.OffloadInserted) {
+		ch <- prometheus.MustNewConstMetric(collector.offloadInsertedMetric, prometheus.CounterValue, float64(ovsMetric.OffloadInserted))
+	}
+	if isValidMetric(ovsMetric.OffloadCtUniDirConnections) {
+		ch <- prometheus.MustNewConstMetric(collector.offloadCtUniDirConnMetric, prometheus.CounterValue, float64(ovsMetric.OffloadCtUniDirConnections))
+	}
+	if isValidMetric(ovsMetric.OffloadCtBiDirConnections) {
+		ch <- prometheus.MustNewConstMetric(collector.offloadCtBiDirConnMetric, prometheus.CounterValue, float64(ovsMetric.OffloadCtBiDirConnections))
+	}
+	if isValidMetric(ovsMetric.OffloadCumAvgLatencyUs) {
+		ch <- prometheus.MustNewConstMetric(collector.offloadCumAvgLatencyUsMetric, prometheus.GaugeValue, float64(ovsMetric.OffloadCumAvgLatencyUs))
+	}
+	if isValidMetric(ovsMetric.OffloadCumLatencyStddevUs) {
+		ch <- prometheus.MustNewConstMetric(collector.offloadCumLatencyStddevUsMetric, prometheus.GaugeValue, float64(ovsMetric.OffloadCumLatencyStddevUs))
+	}
+	if isValidMetric(ovsMetric.OffloadCumLatencyMaxUs) {
+		ch <- prometheus.MustNewConstMetric(collector.offloadCumLatencyMaxUsMetric, prometheus.GaugeValue, float64(ovsMetric.OffloadCumLatencyMaxUs))
+	}
+	if isValidMetric(ovsMetric.OffloadCumLatencyMinUs) {
+		ch <- prometheus.MustNewConstMetric(collector.offloadCumLatencyMinUsMetric, prometheus.GaugeValue, float64(ovsMetric.OffloadCumLatencyMinUs))
+	}
+	if isValidMetric(ovsMetric.OffloadExpAvgLatencyUs) {
+		ch <- prometheus.MustNewConstMetric(collector.offloadExpAvgLatencyUsMetric, prometheus.GaugeValue, float64(ovsMetric.OffloadExpAvgLatencyUs))
+	}
+	if isValidMetric(ovsMetric.OffloadExpLatencyStddevUs) {
+		ch <- prometheus.MustNewConstMetric(collector.offloadExpLatencyStddevUsMetric, prometheus.GaugeValue, float64(ovsMetric.OffloadExpLatencyStddevUs))
 	}
 	// Drop reasons
 	if isValidMetric(ovsMetric.UpcallDrops) {

--- a/metric.go
+++ b/metric.go
@@ -14,6 +14,17 @@ type OvsMetric struct {
 	AvgSubtableLookupsMegaflow float64
 	ProcessingCycles           float64
 	IdleCycles                 float64
+	// Offload stats
+	OffloadEnqueued            float64
+	OffloadInserted            float64
+	OffloadCtUniDirConnections float64
+	OffloadCtBiDirConnections  float64
+	OffloadCumAvgLatencyUs     float64
+	OffloadCumLatencyStddevUs  float64
+	OffloadCumLatencyMaxUs     float64
+	OffloadCumLatencyMinUs     float64
+	OffloadExpAvgLatencyUs     float64
+	OffloadExpLatencyStddevUs  float64
 	// Drop reasons
 	UpcallDrops                      float64
 	UpcallDropsLockError             float64
@@ -72,6 +83,14 @@ func getOvsMetric() *OvsMetric {
 		fmt.Printf("Error running command: %v\n", err)
 	} else {
 		parsePMDStats(&ovsMetric, string(pmdStatsOutput))
+	}
+
+	cmd = exec.Command("/usr/bin/ovs-appctl", "dpctl/offload-stats-show")
+	offloadStatsOutput, err := cmd.CombinedOutput()
+	if err != nil {
+		fmt.Printf("Error running command: %v\n", err)
+	} else {
+		parseOffloadStats(&ovsMetric, string(offloadStatsOutput))
 	}
 
 	cmd = exec.Command("/usr/bin/ovs-appctl", "coverage/show")
@@ -610,6 +629,82 @@ func parsePMDStats(metrics *OvsMetric, pmdStats string) {
 		v, err := strconv.ParseFloat(avgSubtableLookupsMegaflowMatch[1], 64)
 		if err == nil {
 			metrics.AvgSubtableLookupsMegaflow = v
+		}
+	}
+}
+
+func parseOffloadStats(metrics *OvsMetric, offloadStats string) {
+	// Initialize as invalid
+	metrics.OffloadEnqueued = -1
+	metrics.OffloadInserted = -1
+	metrics.OffloadCtUniDirConnections = -1
+	metrics.OffloadCtBiDirConnections = -1
+	metrics.OffloadCumAvgLatencyUs = -1
+	metrics.OffloadCumLatencyStddevUs = -1
+	metrics.OffloadCumLatencyMaxUs = -1
+	metrics.OffloadCumLatencyMinUs = -1
+	metrics.OffloadExpAvgLatencyUs = -1
+	metrics.OffloadExpLatencyStddevUs = -1
+
+	enqueuedRegexp := regexp.MustCompile(`(?m)^[ \t]*Total[ \t]+Enqueued offloads:[ \t]*([0-9]+)`)
+	insertedRegexp := regexp.MustCompile(`(?m)^[ \t]*Total[ \t]+Inserted offloads:[ \t]*([0-9]+)`)
+	ctUniDirRegexp := regexp.MustCompile(`(?m)^[ \t]*Total[ \t]+CT uni-dir Connections:[ \t]*([0-9]+)`)
+	ctBiDirRegexp := regexp.MustCompile(`(?m)^[ \t]*Total[ \t]+CT bi-dir Connections:[ \t]*([0-9]+)`)
+	cumAvgLatRegexp := regexp.MustCompile(`(?m)^[ \t]*Total[ \t]+Cumulative Average latency \(us\):[ \t]*([0-9]+)`)
+	cumStddevRegexp := regexp.MustCompile(`(?m)^[ \t]*Total[ \t]+Cumulative Latency stddev \(us\):[ \t]*([0-9]+)`)
+	cumMaxRegexp := regexp.MustCompile(`(?m)^[ \t]*Total[ \t]+Cumulative Latency max \(us\):[ \t]*([0-9]+)`)
+	cumMinRegexp := regexp.MustCompile(`(?m)^[ \t]*Total[ \t]+Cumulative Latency min \(us\):[ \t]*([0-9]+)`)
+	expAvgLatRegexp := regexp.MustCompile(`(?m)^[ \t]*Total[ \t]+Exponential Average latency \(us\):[ \t]*([0-9]+)`)
+	expStddevRegexp := regexp.MustCompile(`(?m)^[ \t]*Total[ \t]+Exponential Latency stddev \(us\):[ \t]*([0-9]+)`)
+
+	if m := enqueuedRegexp.FindStringSubmatch(offloadStats); len(m) > 1 {
+		if v, err := strconv.ParseFloat(m[1], 64); err == nil {
+			metrics.OffloadEnqueued = v
+		}
+	}
+	if m := insertedRegexp.FindStringSubmatch(offloadStats); len(m) > 1 {
+		if v, err := strconv.ParseFloat(m[1], 64); err == nil {
+			metrics.OffloadInserted = v
+		}
+	}
+	if m := ctUniDirRegexp.FindStringSubmatch(offloadStats); len(m) > 1 {
+		if v, err := strconv.ParseFloat(m[1], 64); err == nil {
+			metrics.OffloadCtUniDirConnections = v
+		}
+	}
+	if m := ctBiDirRegexp.FindStringSubmatch(offloadStats); len(m) > 1 {
+		if v, err := strconv.ParseFloat(m[1], 64); err == nil {
+			metrics.OffloadCtBiDirConnections = v
+		}
+	}
+	if m := cumAvgLatRegexp.FindStringSubmatch(offloadStats); len(m) > 1 {
+		if v, err := strconv.ParseFloat(m[1], 64); err == nil {
+			metrics.OffloadCumAvgLatencyUs = v
+		}
+	}
+	if m := cumStddevRegexp.FindStringSubmatch(offloadStats); len(m) > 1 {
+		if v, err := strconv.ParseFloat(m[1], 64); err == nil {
+			metrics.OffloadCumLatencyStddevUs = v
+		}
+	}
+	if m := cumMaxRegexp.FindStringSubmatch(offloadStats); len(m) > 1 {
+		if v, err := strconv.ParseFloat(m[1], 64); err == nil {
+			metrics.OffloadCumLatencyMaxUs = v
+		}
+	}
+	if m := cumMinRegexp.FindStringSubmatch(offloadStats); len(m) > 1 {
+		if v, err := strconv.ParseFloat(m[1], 64); err == nil {
+			metrics.OffloadCumLatencyMinUs = v
+		}
+	}
+	if m := expAvgLatRegexp.FindStringSubmatch(offloadStats); len(m) > 1 {
+		if v, err := strconv.ParseFloat(m[1], 64); err == nil {
+			metrics.OffloadExpAvgLatencyUs = v
+		}
+	}
+	if m := expStddevRegexp.FindStringSubmatch(offloadStats); len(m) > 1 {
+		if v, err := strconv.ParseFloat(m[1], 64); err == nil {
+			metrics.OffloadExpLatencyStddevUs = v
 		}
 	}
 }

--- a/metric.go
+++ b/metric.go
@@ -25,6 +25,14 @@ type OvsMetric struct {
 	OffloadCumLatencyMinUs     float64
 	OffloadExpAvgLatencyUs     float64
 	OffloadExpLatencyStddevUs  float64
+	// Memory/show stats
+	MemoryHandlers            float64
+	MemoryIdlCellsOpenVSwitch float64
+	MemoryOfconns             float64
+	MemoryPorts               float64
+	MemoryRevalidators        float64
+	MemoryRules               float64
+	MemoryUdpifKeys           float64
 	// Drop reasons
 	UpcallDrops                      float64
 	UpcallDropsLockError             float64
@@ -91,6 +99,14 @@ func getOvsMetric() *OvsMetric {
 		fmt.Printf("Error running command: %v\n", err)
 	} else {
 		parseOffloadStats(&ovsMetric, string(offloadStatsOutput))
+	}
+
+	cmd = exec.Command("/usr/bin/ovs-appctl", "memory/show")
+	memoryShowOutput, err := cmd.CombinedOutput()
+	if err != nil {
+		fmt.Printf("Error running command: %v\n", err)
+	} else {
+		parseMemoryShow(&ovsMetric, string(memoryShowOutput))
 	}
 
 	cmd = exec.Command("/usr/bin/ovs-appctl", "coverage/show")
@@ -705,6 +721,60 @@ func parseOffloadStats(metrics *OvsMetric, offloadStats string) {
 	if m := expStddevRegexp.FindStringSubmatch(offloadStats); len(m) > 1 {
 		if v, err := strconv.ParseFloat(m[1], 64); err == nil {
 			metrics.OffloadExpLatencyStddevUs = v
+		}
+	}
+}
+
+func parseMemoryShow(metrics *OvsMetric, memoryShow string) {
+	metrics.MemoryHandlers = -1
+	metrics.MemoryIdlCellsOpenVSwitch = -1
+	metrics.MemoryOfconns = -1
+	metrics.MemoryPorts = -1
+	metrics.MemoryRevalidators = -1
+	metrics.MemoryRules = -1
+	metrics.MemoryUdpifKeys = -1
+
+	handlersRegexp := regexp.MustCompile(`(?m)handlers:\s*(\d+)`)
+	idlCellsRegexp := regexp.MustCompile(`(?m)idl-cells-Open_vSwitch:\s*(\d+)`)
+	ofconnsRegexp := regexp.MustCompile(`(?m)ofconns:\s*(\d+)`)
+	portsRegexp := regexp.MustCompile(`(?m)ports:\s*(\d+)`)
+	revalidatorsRegexp := regexp.MustCompile(`(?m)revalidators:\s*(\d+)`)
+	rulesRegexp := regexp.MustCompile(`(?m)rules:\s*(\d+)`)
+	udpifKeysRegexp := regexp.MustCompile(`(?m)udpif keys:\s*(\d+)`)
+
+	if m := handlersRegexp.FindStringSubmatch(memoryShow); len(m) > 1 {
+		if v, err := strconv.ParseFloat(m[1], 64); err == nil {
+			metrics.MemoryHandlers = v
+		}
+	}
+	if m := idlCellsRegexp.FindStringSubmatch(memoryShow); len(m) > 1 {
+		if v, err := strconv.ParseFloat(m[1], 64); err == nil {
+			metrics.MemoryIdlCellsOpenVSwitch = v
+		}
+	}
+	if m := ofconnsRegexp.FindStringSubmatch(memoryShow); len(m) > 1 {
+		if v, err := strconv.ParseFloat(m[1], 64); err == nil {
+			metrics.MemoryOfconns = v
+		}
+	}
+	if m := portsRegexp.FindStringSubmatch(memoryShow); len(m) > 1 {
+		if v, err := strconv.ParseFloat(m[1], 64); err == nil {
+			metrics.MemoryPorts = v
+		}
+	}
+	if m := revalidatorsRegexp.FindStringSubmatch(memoryShow); len(m) > 1 {
+		if v, err := strconv.ParseFloat(m[1], 64); err == nil {
+			metrics.MemoryRevalidators = v
+		}
+	}
+	if m := rulesRegexp.FindStringSubmatch(memoryShow); len(m) > 1 {
+		if v, err := strconv.ParseFloat(m[1], 64); err == nil {
+			metrics.MemoryRules = v
+		}
+	}
+	if m := udpifKeysRegexp.FindStringSubmatch(memoryShow); len(m) > 1 {
+		if v, err := strconv.ParseFloat(m[1], 64); err == nil {
+			metrics.MemoryUdpifKeys = v
 		}
 	}
 }

--- a/metric_test.go
+++ b/metric_test.go
@@ -261,3 +261,37 @@ avg. packets per output batch: 0.00`,
 		})
 	}
 }
+
+func Test_parseOffloadStats(t *testing.T) {
+	input := `HW Offload stats:
+     Total                 Enqueued offloads:       0
+     Total                 Inserted offloads:    8283
+     Total            CT uni-dir Connections:       0
+     Total             CT bi-dir Connections:       0
+     Total   Cumulative Average latency (us):   14882
+     Total    Cumulative Latency stddev (us):   14689
+     Total       Cumulative Latency max (us):  692044
+     Total       Cumulative Latency min (us):       3
+     Total  Exponential Average latency (us):   14381
+     Total   Exponential Latency stddev (us):   11337`
+
+	var got OvsMetric
+	parseOffloadStats(&got, input)
+
+	want := OvsMetric{
+		OffloadEnqueued:            0,
+		OffloadInserted:            8283,
+		OffloadCtUniDirConnections: 0,
+		OffloadCtBiDirConnections:  0,
+		OffloadCumAvgLatencyUs:     14882,
+		OffloadCumLatencyStddevUs:  14689,
+		OffloadCumLatencyMaxUs:     692044,
+		OffloadCumLatencyMinUs:     3,
+		OffloadExpAvgLatencyUs:     14381,
+		OffloadExpLatencyStddevUs:  11337,
+	}
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Fatalf("parseOffloadStats mismatch (-got +want):\n%s", diff)
+	}
+}

--- a/metric_test.go
+++ b/metric_test.go
@@ -295,3 +295,24 @@ func Test_parseOffloadStats(t *testing.T) {
 		t.Fatalf("parseOffloadStats mismatch (-got +want):\n%s", diff)
 	}
 }
+
+func Test_parseMemoryShow(t *testing.T) {
+	input := `handlers:11 idl-cells-Open_vSwitch:2742 ofconns:2 ports:47 revalidators:5 rules:20658 udpif keys:29`
+
+	var got OvsMetric
+	parseMemoryShow(&got, input)
+
+	want := OvsMetric{
+		MemoryHandlers:            11,
+		MemoryIdlCellsOpenVSwitch: 2742,
+		MemoryOfconns:             2,
+		MemoryPorts:               47,
+		MemoryRevalidators:        5,
+		MemoryRules:               20658,
+		MemoryUdpifKeys:           29,
+	}
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Fatalf("parseMemoryShow mismatch (-got +want):\n%s", diff)
+	}
+}


### PR DESCRIPTION
- Parse dpctl/offload-stats-show and memory/show and export new Prometheus metrics.
- Add unit tests for both parsers; go test ./... passes.
- Improve metric help text to reflect OVS component roles.