### PR TITLE
Fail scrape when all ovs-appctl commands fail; add unit test

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"fmt"
+
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -432,7 +434,11 @@ func (collector *ovsDPCollector) Describe(ch chan<- *prometheus.Desc) {
 }
 
 func (collector *ovsDPCollector) Collect(ch chan<- prometheus.Metric) {
-	ovsMetric := getOvsMetric()
+	ovsMetric, successCount := getOvsMetric()
+	if successCount == 0 {
+		ch <- prometheus.NewInvalidMetric(prometheus.NewDesc("ovsdp_scrape_error", "Scrape failed: all ovs-appctl commands failed", nil, nil), fmt.Errorf("all ovs-appctl commands failed"))
+		return
+	}
 	// PMD stats
 	if isValidMetric(ovsMetric.MissWithSuccessUpcall) {
 		ch <- prometheus.MustNewConstMetric(collector.missWithSuccessUpcallMetric, prometheus.CounterValue, float64(ovsMetric.MissWithSuccessUpcall))

--- a/exporter.go
+++ b/exporter.go
@@ -81,6 +81,9 @@ type ovsDPCollector struct {
 	UpcallFlowLimitScaledMetric  *prometheus.Desc
 }
 
+// allow tests to stub metric fetching
+var fetchOvsMetrics = getOvsMetric
+
 func isValidMetric(value float64) bool {
 	return value != -1
 }
@@ -434,7 +437,7 @@ func (collector *ovsDPCollector) Describe(ch chan<- *prometheus.Desc) {
 }
 
 func (collector *ovsDPCollector) Collect(ch chan<- prometheus.Metric) {
-	ovsMetric, successCount := getOvsMetric()
+	ovsMetric, successCount := fetchOvsMetrics()
 	if successCount == 0 {
 		ch <- prometheus.NewInvalidMetric(prometheus.NewDesc("ovsdp_scrape_error", "Scrape failed: all ovs-appctl commands failed", nil, nil), fmt.Errorf("all ovs-appctl commands failed"))
 		return

--- a/main.go
+++ b/main.go
@@ -22,7 +22,7 @@ func main() {
 	registry.MustRegister(collector)
 
 	fmt.Printf("Starting server listening: %s\n", *host)
-	http.Handle(*pathname, promhttp.HandlerFor(registry, promhttp.HandlerOpts{}))
+	http.Handle(*pathname, promhttp.HandlerFor(registry, promhttp.HandlerOpts{ErrorHandling: promhttp.HTTPErrorOnError}))
 	http.ListenAndServe(*host, nil)
 
 }

--- a/metric.go
+++ b/metric.go
@@ -82,23 +82,26 @@ type OvsMetric struct {
 	UpcallFlowLimitScaled  float64
 }
 
-func getOvsMetric() *OvsMetric {
-	var ovsMetric OvsMetric
+func getOvsMetric() (*OvsMetric, int) {
+    var ovsMetric OvsMetric
+    successCount := 0
 
 	cmd := exec.Command("/usr/bin/ovs-appctl", "dpif-netdev/pmd-stats-show")
 	pmdStatsOutput, err := cmd.CombinedOutput()
-	if err != nil {
+    if err != nil {
 		fmt.Printf("Error running command: %v\n", err)
 	} else {
 		parsePMDStats(&ovsMetric, string(pmdStatsOutput))
+        successCount++
 	}
 
 	cmd = exec.Command("/usr/bin/ovs-appctl", "dpctl/offload-stats-show")
 	offloadStatsOutput, err := cmd.CombinedOutput()
-	if err != nil {
+    if err != nil {
 		fmt.Printf("Error running command: %v\n", err)
 	} else {
 		parseOffloadStats(&ovsMetric, string(offloadStatsOutput))
+        successCount++
 	}
 
 	cmd = exec.Command("/usr/bin/ovs-appctl", "memory/show")
@@ -111,14 +114,15 @@ func getOvsMetric() *OvsMetric {
 
 	cmd = exec.Command("/usr/bin/ovs-appctl", "coverage/show")
 	coverageOutput, err := cmd.CombinedOutput()
-	if err != nil {
+    if err != nil {
 		fmt.Printf("Error running command: %v\n", err)
 	} else {
 		parseCoverageDropReasons(&ovsMetric, string(coverageOutput))
 		parseCoverageDoca(&ovsMetric, string(coverageOutput))
+        successCount++
 	}
 
-	return &ovsMetric
+    return &ovsMetric, successCount
 }
 
 func parseCoverageDoca(metrics *OvsMetric, coverageStats string) {

--- a/metric_test.go
+++ b/metric_test.go
@@ -1,9 +1,13 @@
 package main
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 func Test_parseCoverageDoca(t *testing.T) {
@@ -259,6 +263,31 @@ avg. packets per output batch: 0.00`,
 				t.Errorf("Structs are different:\n%s", diff)
 			}
 		})
+	}
+}
+
+// Minimal test to assert scrape fails (HTTP 500) when all commands fail
+// by stubbing fetchOvsMetrics to return successCount=0 and then invoking
+// the Prometheus handler.
+func Test_ScrapeFailWhenAllCommandsFail(t *testing.T) {
+	// Why copy to "old" and restore it later?
+	// We replace the global fetch function to simulate total failure for THIS test only.
+	// Saving the original (old) and restoring it prevents leaking the stub into other tests
+	// (order-dependent bugs, parallel test flakiness, and masking real integrations).
+	old := fetchOvsMetrics
+	fetchOvsMetrics = func() (*OvsMetric, int) { return &OvsMetric{}, 0 }
+	t.Cleanup(func() { fetchOvsMetrics = old })
+
+	reg := prometheus.NewRegistry()
+	reg.MustRegister(newOvsDPCollector())
+
+	req := httptest.NewRequest("GET", "/metrics", nil)
+	w := httptest.NewRecorder()
+	h := promhttp.HandlerFor(reg, promhttp.HandlerOpts{ErrorHandling: promhttp.HTTPErrorOnError})
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500 when all commands fail, got %d", w.Code)
 	}
 }
 


### PR DESCRIPTION
- Return HTTP 500 on scrape when all OVS commands fail; emit InvalidMetric for clarity.
- Wire handler to promhttp HTTPErrorOnError to propagate errors.
- Add test stubbing fetchOvsMetrics to simulate total failure; assert 500 response.