### PR TITLE
parse doca-pipe-group and compute total mask/pipe per group

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -81,6 +81,15 @@ type ovsDPCollector struct {
 	UpcallFlowLimitScaledMetric  *prometheus.Desc
 	// DOCA Pipe Group
 	docaUniqueItemTemplatesMetric *prometheus.Desc
+	// DOCA Pipe Group Entries
+	docaPipegroupMainEntriesMetric          *prometheus.Desc
+	docaPipegroupSamplePostmirrorEntriesMetric *prometheus.Desc
+	docaPipegroupSplitPostprefixEntriesMetric  *prometheus.Desc
+	docaPipegroupPosthashEntriesMetric         *prometheus.Desc
+	docaPipegroupPostctEntriesMetric           *prometheus.Desc
+	docaPipegroupPostmeterEntriesMetric        *prometheus.Desc
+	docaPipegroupCtEntriesMetric               *prometheus.Desc
+	docaPipegroupCtnatEntriesMetric            *prometheus.Desc
 }
 
 // allow tests to stub metric fetching
@@ -362,6 +371,39 @@ func newOvsDPCollector() *ovsDPCollector {
 		// DOCA Pipe Group
 		docaUniqueItemTemplatesMetric: prometheus.NewDesc("ovsdp_doca_unique_item_templates",
 			"Number of unique item templates created from doca-pipe-group/dump",
+			nil, nil,
+		),
+		// DOCA Pipe Group Entries
+		docaPipegroupMainEntriesMetric: prometheus.NewDesc("ovsdp_doca_pipegroup_main_entries",
+			"Number of entries in the main pipe group (group_id=0x00000000)",
+			nil, nil,
+		),
+		docaPipegroupSamplePostmirrorEntriesMetric: prometheus.NewDesc("ovsdp_doca_pipegroup_sample_postmirror_entries",
+			"Number of entries in the sample-post-mirror pipe group (group_id=0xf2000000)",
+			nil, nil,
+		),
+		docaPipegroupSplitPostprefixEntriesMetric: prometheus.NewDesc("ovsdp_doca_pipegroup_split_postprefix_entries",
+			"Number of entries in the split-post-prefix pipe group (group_id=0xfa000000)",
+			nil, nil,
+		),
+		docaPipegroupPosthashEntriesMetric: prometheus.NewDesc("ovsdp_doca_pipegroup_posthash_entries",
+			"Number of entries in the post-hash pipe group (group_id=0xfb000000)",
+			nil, nil,
+		),
+		docaPipegroupPostctEntriesMetric: prometheus.NewDesc("ovsdp_doca_pipegroup_postct_entries",
+			"Number of entries in the post-ct pipe group (group_id=0xfd000000)",
+			nil, nil,
+		),
+		docaPipegroupPostmeterEntriesMetric: prometheus.NewDesc("ovsdp_doca_pipegroup_postmeter_entries",
+			"Number of entries in the post-meter pipe group (group_id=0xff000000)",
+			nil, nil,
+		),
+		docaPipegroupCtEntriesMetric: prometheus.NewDesc("ovsdp_doca_pipegroup_ct_entries",
+			"Number of entries in all CT pipe groups (group_id=0xfc0xxxxx)",
+			nil, nil,
+		),
+		docaPipegroupCtnatEntriesMetric: prometheus.NewDesc("ovsdp_doca_pipegroup_ctnat_entries",
+			"Number of entries in all CT-NAT pipe groups (group_id=0xfc1xxxxx)",
 			nil, nil,
 		),
 	}
@@ -656,6 +698,31 @@ func (collector *ovsDPCollector) Collect(ch chan<- prometheus.Metric) {
 	// DOCA Pipe Group
 	if isValidMetric(ovsMetric.DocaUniqueItemTemplates) {
 		ch <- prometheus.MustNewConstMetric(collector.docaUniqueItemTemplatesMetric, prometheus.GaugeValue, float64(ovsMetric.DocaUniqueItemTemplates))
+	}
+	// DOCA Pipe Group Entries
+	if isValidMetric(ovsMetric.DocaPipegroupMainEntries) {
+		ch <- prometheus.MustNewConstMetric(collector.docaPipegroupMainEntriesMetric, prometheus.GaugeValue, float64(ovsMetric.DocaPipegroupMainEntries))
+	}
+	if isValidMetric(ovsMetric.DocaPipegroupSamplePostmirrorEntries) {
+		ch <- prometheus.MustNewConstMetric(collector.docaPipegroupSamplePostmirrorEntriesMetric, prometheus.GaugeValue, float64(ovsMetric.DocaPipegroupSamplePostmirrorEntries))
+	}
+	if isValidMetric(ovsMetric.DocaPipegroupSplitPostprefixEntries) {
+		ch <- prometheus.MustNewConstMetric(collector.docaPipegroupSplitPostprefixEntriesMetric, prometheus.GaugeValue, float64(ovsMetric.DocaPipegroupSplitPostprefixEntries))
+	}
+	if isValidMetric(ovsMetric.DocaPipegroupPosthashEntries) {
+		ch <- prometheus.MustNewConstMetric(collector.docaPipegroupPosthashEntriesMetric, prometheus.GaugeValue, float64(ovsMetric.DocaPipegroupPosthashEntries))
+	}
+	if isValidMetric(ovsMetric.DocaPipegroupPostctEntries) {
+		ch <- prometheus.MustNewConstMetric(collector.docaPipegroupPostctEntriesMetric, prometheus.GaugeValue, float64(ovsMetric.DocaPipegroupPostctEntries))
+	}
+	if isValidMetric(ovsMetric.DocaPipegroupPostmeterEntries) {
+		ch <- prometheus.MustNewConstMetric(collector.docaPipegroupPostmeterEntriesMetric, prometheus.GaugeValue, float64(ovsMetric.DocaPipegroupPostmeterEntries))
+	}
+	if isValidMetric(ovsMetric.DocaPipegroupCtEntries) {
+		ch <- prometheus.MustNewConstMetric(collector.docaPipegroupCtEntriesMetric, prometheus.GaugeValue, float64(ovsMetric.DocaPipegroupCtEntries))
+	}
+	if isValidMetric(ovsMetric.DocaPipegroupCtnatEntries) {
+		ch <- prometheus.MustNewConstMetric(collector.docaPipegroupCtnatEntriesMetric, prometheus.GaugeValue, float64(ovsMetric.DocaPipegroupCtnatEntries))
 	}
 
 	// Collect parsed metrics from ovs-appctl metrics/show

--- a/metric.go
+++ b/metric.go
@@ -87,6 +87,15 @@ type OvsMetric struct {
 	UpcallFlowLimitScaled  float64
 	// DOCA Pipe Group
 	DocaUniqueItemTemplates float64
+	// DOCA Pipe Group Entries
+	DocaPipegroupMainEntries          float64
+	DocaPipegroupSamplePostmirrorEntries float64
+	DocaPipegroupSplitPostprefixEntries  float64
+	DocaPipegroupPosthashEntries         float64
+	DocaPipegroupPostctEntries           float64
+	DocaPipegroupPostmeterEntries        float64
+	DocaPipegroupCtEntries               float64
+	DocaPipegroupCtnatEntries            float64
 	// Parsed metrics from ovs-appctl metrics/show
 	ParsedMetrics []*dto.MetricFamily
 }
@@ -170,6 +179,23 @@ func getOvsMetric() (*OvsMetric, int) {
 		parseDocaUniqueTemplates(&ovsMetric, string(docaPipeGroupOutput))
 	}
 
+	// Parse DOCA pipe group entries
+	cmd = exec.Command("/usr/bin/ovs-appctl", "doca-pipe-group/dump")
+	docaPipeGroupDumpOutput, err := cmd.CombinedOutput()
+	if err != nil {
+		fmt.Printf("Error running doca-pipe-group/dump command: %v\n", err)
+		ovsMetric.DocaPipegroupMainEntries = -1
+		ovsMetric.DocaPipegroupSamplePostmirrorEntries = -1
+		ovsMetric.DocaPipegroupSplitPostprefixEntries = -1
+		ovsMetric.DocaPipegroupPosthashEntries = -1
+		ovsMetric.DocaPipegroupPostctEntries = -1
+		ovsMetric.DocaPipegroupPostmeterEntries = -1
+		ovsMetric.DocaPipegroupCtEntries = -1
+		ovsMetric.DocaPipegroupCtnatEntries = -1
+	} else {
+		parseDocaPipegroupEntries(&ovsMetric, string(docaPipeGroupDumpOutput))
+	}
+
 	return &ovsMetric, successCount
 }
 
@@ -188,6 +214,75 @@ func parseDocaUniqueTemplates(metrics *OvsMetric, output string) {
 	}
 
 	metrics.DocaUniqueItemTemplates = count
+}
+
+func parseDocaPipegroupEntries(metrics *OvsMetric, output string) {
+	// Initialize all metrics to -1
+	metrics.DocaPipegroupMainEntries = -1
+	metrics.DocaPipegroupSamplePostmirrorEntries = -1
+	metrics.DocaPipegroupSplitPostprefixEntries = -1
+	metrics.DocaPipegroupPosthashEntries = -1
+	metrics.DocaPipegroupPostctEntries = -1
+	metrics.DocaPipegroupPostmeterEntries = -1
+	metrics.DocaPipegroupCtEntries = -1
+	metrics.DocaPipegroupCtnatEntries = -1
+
+	if strings.TrimSpace(output) == "" {
+		return
+	}
+
+	lines := strings.Split(output, "\n")
+
+	// Counters for each pipe group
+	var mainCount, samplePostmirrorCount, splitPostprefixCount, posthashCount float64
+	var postctCount, postmeterCount, ctCount, ctnatCount float64
+
+	for _, line := range lines {
+		// Skip empty lines or lines that don't start with esw=
+		if !strings.HasPrefix(line, "esw=") {
+			continue
+		}
+
+		// Extract group_id from the line
+		groupIDMatch := regexp.MustCompile(`group_id=(0x[0-9a-fA-F]+)`).FindStringSubmatch(line)
+		if len(groupIDMatch) < 2 {
+			continue
+		}
+
+		groupID := groupIDMatch[1]
+
+		// Count entries based on group_id
+		switch {
+		case groupID == "0x00000000":
+			mainCount++
+		case groupID == "0xf2000000":
+			samplePostmirrorCount++
+		case groupID == "0xfa000000":
+			splitPostprefixCount++
+		case groupID == "0xfb000000":
+			posthashCount++
+		case groupID == "0xfd000000":
+			postctCount++
+		case groupID == "0xff000000":
+			postmeterCount++
+		case strings.HasPrefix(groupID, "0xfc1"):
+			// CTNAT entries (0xfc10xxxx)
+			ctnatCount++
+		case strings.HasPrefix(groupID, "0xfc0"):
+			// CT entries (0xfc0xxxxx but not 0xfc1xxxxx)
+			ctCount++
+		}
+	}
+
+	// Set the metrics
+	metrics.DocaPipegroupMainEntries = mainCount
+	metrics.DocaPipegroupSamplePostmirrorEntries = samplePostmirrorCount
+	metrics.DocaPipegroupSplitPostprefixEntries = splitPostprefixCount
+	metrics.DocaPipegroupPosthashEntries = posthashCount
+	metrics.DocaPipegroupPostctEntries = postctCount
+	metrics.DocaPipegroupPostmeterEntries = postmeterCount
+	metrics.DocaPipegroupCtEntries = ctCount
+	metrics.DocaPipegroupCtnatEntries = ctnatCount
 }
 
 func parseCoverageDoca(metrics *OvsMetric, coverageStats string) {

--- a/metric_test.go
+++ b/metric_test.go
@@ -2402,3 +2402,257 @@ func Test_parseDocaUniqueTemplates(t *testing.T) {
 		})
 	}
 }
+
+func Test_parseDocaPipegroupEntries(t *testing.T) {
+	tests := []struct {
+		name   string
+		output string
+		metric OvsMetric
+	}{
+		{
+			name: "all pipe groups with entries",
+			output: `esw=0,group_id=0x00000000,priority=2,match=eth,actions=drop
+esw=0,group_id=0x00000000,priority=1,match=ip,actions=normal
+esw=1,group_id=0xf2000000,priority=5,match=tcp,actions=output:1
+esw=1,group_id=0xf2000000,priority=3,match=udp,actions=output:2
+esw=0,group_id=0xfa000000,priority=10,match=icmp,actions=drop
+esw=0,group_id=0xfb000000,priority=1,match=arp,actions=normal
+esw=1,group_id=0xfb000000,priority=2,match=ip,actions=output:3
+esw=0,group_id=0xfd000000,priority=7,match=tcp,actions=ct
+esw=0,group_id=0xff000000,priority=4,match=udp,actions=meter
+esw=1,group_id=0xff000000,priority=6,match=tcp,actions=meter
+esw=0,group_id=0xfc00012d,priority=8,match=tcp,actions=ct
+esw=1,group_id=0xfc000042,priority=9,match=udp,actions=ct
+esw=0,group_id=0xfc10012d,priority=11,match=tcp,actions=nat
+esw=1,group_id=0xfc100099,priority=12,match=udp,actions=nat
+not_esw_line,group_id=0x00000000,priority=1
+esw=0,no_group_id,priority=1`,
+			metric: OvsMetric{
+				DocaPipegroupMainEntries:          2,
+				DocaPipegroupSamplePostmirrorEntries: 2,
+				DocaPipegroupSplitPostprefixEntries:  1,
+				DocaPipegroupPosthashEntries:         2,
+				DocaPipegroupPostctEntries:           1,
+				DocaPipegroupPostmeterEntries:        2,
+				DocaPipegroupCtEntries:               2,
+				DocaPipegroupCtnatEntries:            2,
+			},
+		},
+		{
+			name: "only main pipe group",
+			output: `esw=0,group_id=0x00000000,priority=1,match=ip,actions=normal
+esw=1,group_id=0x00000000,priority=2,match=tcp,actions=drop
+esw=2,group_id=0x00000000,priority=3,match=udp,actions=output:1`,
+			metric: OvsMetric{
+				DocaPipegroupMainEntries:          3,
+				DocaPipegroupSamplePostmirrorEntries: 0,
+				DocaPipegroupSplitPostprefixEntries:  0,
+				DocaPipegroupPosthashEntries:         0,
+				DocaPipegroupPostctEntries:           0,
+				DocaPipegroupPostmeterEntries:        0,
+				DocaPipegroupCtEntries:               0,
+				DocaPipegroupCtnatEntries:            0,
+			},
+		},
+		{
+			name: "only CT and CTNAT entries",
+			output: `esw=0,group_id=0xfc000001,priority=1,match=tcp,actions=ct
+esw=0,group_id=0xfc00012d,priority=2,match=tcp,actions=ct
+esw=0,group_id=0xfc000fff,priority=3,match=udp,actions=ct
+esw=0,group_id=0xfc100001,priority=4,match=tcp,actions=nat
+esw=0,group_id=0xfc10012d,priority=5,match=tcp,actions=nat
+esw=0,group_id=0xfc100fff,priority=6,match=udp,actions=nat`,
+			metric: OvsMetric{
+				DocaPipegroupMainEntries:          0,
+				DocaPipegroupSamplePostmirrorEntries: 0,
+				DocaPipegroupSplitPostprefixEntries:  0,
+				DocaPipegroupPosthashEntries:         0,
+				DocaPipegroupPostctEntries:           0,
+				DocaPipegroupPostmeterEntries:        0,
+				DocaPipegroupCtEntries:               3,
+				DocaPipegroupCtnatEntries:            3,
+			},
+		},
+		{
+			name:   "empty output",
+			output: "",
+			metric: OvsMetric{
+				DocaPipegroupMainEntries:          -1,
+				DocaPipegroupSamplePostmirrorEntries: -1,
+				DocaPipegroupSplitPostprefixEntries:  -1,
+				DocaPipegroupPosthashEntries:         -1,
+				DocaPipegroupPostctEntries:           -1,
+				DocaPipegroupPostmeterEntries:        -1,
+				DocaPipegroupCtEntries:               -1,
+				DocaPipegroupCtnatEntries:            -1,
+			},
+		},
+		{
+			name:   "whitespace only",
+			output: "   \n\n  \n",
+			metric: OvsMetric{
+				DocaPipegroupMainEntries:          -1,
+				DocaPipegroupSamplePostmirrorEntries: -1,
+				DocaPipegroupSplitPostprefixEntries:  -1,
+				DocaPipegroupPosthashEntries:         -1,
+				DocaPipegroupPostctEntries:           -1,
+				DocaPipegroupPostmeterEntries:        -1,
+				DocaPipegroupCtEntries:               -1,
+				DocaPipegroupCtnatEntries:            -1,
+			},
+		},
+		{
+			name: "no esw lines",
+			output: `not_esw=0,group_id=0x00000000,priority=1
+some_other_line
+group_id=0xf2000000,priority=2`,
+			metric: OvsMetric{
+				DocaPipegroupMainEntries:          0,
+				DocaPipegroupSamplePostmirrorEntries: 0,
+				DocaPipegroupSplitPostprefixEntries:  0,
+				DocaPipegroupPosthashEntries:         0,
+				DocaPipegroupPostctEntries:           0,
+				DocaPipegroupPostmeterEntries:        0,
+				DocaPipegroupCtEntries:               0,
+				DocaPipegroupCtnatEntries:            0,
+			},
+		},
+		{
+			name: "esw lines without group_id",
+			output: `esw=0,priority=1,match=ip
+esw=1,priority=2,match=tcp
+esw=2,priority=3,match=udp`,
+			metric: OvsMetric{
+				DocaPipegroupMainEntries:          0,
+				DocaPipegroupSamplePostmirrorEntries: 0,
+				DocaPipegroupSplitPostprefixEntries:  0,
+				DocaPipegroupPosthashEntries:         0,
+				DocaPipegroupPostctEntries:           0,
+				DocaPipegroupPostmeterEntries:        0,
+				DocaPipegroupCtEntries:               0,
+				DocaPipegroupCtnatEntries:            0,
+			},
+		},
+		{
+			name: "mixed case group_id",
+			output: `esw=0,group_id=0x00000000,priority=1,match=ip,actions=normal
+esw=0,group_id=0xF2000000,priority=2,match=tcp,actions=drop
+esw=0,group_id=0xFA000000,priority=3,match=udp,actions=output:1
+esw=0,group_id=0xFB000000,priority=4,match=icmp,actions=normal
+esw=0,group_id=0xFD000000,priority=5,match=arp,actions=ct
+esw=0,group_id=0xFF000000,priority=6,match=tcp,actions=meter
+esw=0,group_id=0xFC00012D,priority=7,match=tcp,actions=ct
+esw=0,group_id=0xFC10012D,priority=8,match=tcp,actions=nat`,
+			metric: OvsMetric{
+				DocaPipegroupMainEntries:          1,
+				DocaPipegroupSamplePostmirrorEntries: 0, // Case sensitive matching
+				DocaPipegroupSplitPostprefixEntries:  0,
+				DocaPipegroupPosthashEntries:         0,
+				DocaPipegroupPostctEntries:           0,
+				DocaPipegroupPostmeterEntries:        0,
+				DocaPipegroupCtEntries:               0,
+				DocaPipegroupCtnatEntries:            0,
+			},
+		},
+		{
+			name: "all infrastructure pipe groups",
+			output: `esw=0,group_id=0xf2000000,priority=1,match=tcp,actions=mirror
+esw=0,group_id=0xfa000000,priority=2,match=tcp,actions=split
+esw=0,group_id=0xfb000000,priority=3,match=tcp,actions=hash
+esw=0,group_id=0xfd000000,priority=4,match=tcp,actions=postct
+esw=0,group_id=0xff000000,priority=5,match=tcp,actions=meter`,
+			metric: OvsMetric{
+				DocaPipegroupMainEntries:          0,
+				DocaPipegroupSamplePostmirrorEntries: 1,
+				DocaPipegroupSplitPostprefixEntries:  1,
+				DocaPipegroupPosthashEntries:         1,
+				DocaPipegroupPostctEntries:           1,
+				DocaPipegroupPostmeterEntries:        1,
+				DocaPipegroupCtEntries:               0,
+				DocaPipegroupCtnatEntries:            0,
+			},
+		},
+		{
+			name: "real command output with detailed entries",
+			output: `esw_mgr_port_id=0, group_id=0xf2000000 (sample-post-mirror)
+esw=0xffff128ff048, group_id=0xf2000000 (sample-post-mirror), priority=1, fwd.type=drop, match.outer.eth.type[2,changeable]=0xffff/0x8809, empty_actions_mask
+esw=0xffff128ff048, group_id=0xf2000000 (sample-post-mirror), priority=3, fwd.type=pipe, empty_match, actions.meta.pkt_meta[4,changeable]=0xffffffff/0x00f0ffff
+esw_mgr_port_id=0, group_id=0xf1000000 (sample)
+esw_mgr_port_id=0, group_id=0x00000000
+esw=0xffff128ff048, group_id=0x00000000, priority=1, fwd.type=port, match.parser_meta.port_meta[4,changeable]=0xffffffff/0xffffffff, match.parser_meta.outer_ip_fragmented[1,changeable]=0xff/0xff, match.outer.eth.type[2,changeable]=0xffff/0xffff, match.outer.l3_type[4,specific]=0x01000000/0x01000000, empty_actions_mask
+esw=0xffff128ff048, group_id=0x00000000, priority=1, fwd.type=drop, match.parser_meta.port_meta[4,changeable]=0xffffffff/0xffffffff, match.parser_meta.outer_ip_fragmented[1,changeable]=0xff/0xff, match.outer.eth.type[2,changeable]=0xffff/0xffff, match.outer.l3_type[4,specific]=0x01000000/0x01000000, empty_actions_mask
+esw=0xffff128ff048, group_id=0x00000000, priority=1, fwd.type=pipe, match.parser_meta.port_meta[4,changeable]=0xffffffff/0xffffffff, match.parser_meta.outer_ip_fragmented[1,changeable]=0xff/0xff, match.outer.eth.type[2,changeable]=0xffff/0xffff, match.outer.eth.dst_mac[6,changeable]=0xffffffffffff/0xffffffff0000, match.outer.l3_type[4,specific]=0x01000000/0x01000000, match.outer.ip4.next_proto[1,changeable]=0xff/0xff, match.outer.l4_type_ext[4,specific]=0x01000000/0x01000000, match.outer.tcp.l4_port.src_port[2,changeable]=0xffff/0xffff, match.outer.tcp.l4_port.dst_port[2,changeable]=0xffff/0x8000, actions.meta.pkt_meta[4,changeable]=0xffffffff/0x00f0ffff
+esw=0xffff128ff048, group_id=0x00000000, priority=1, fwd.type=pipe, match.parser_meta.port_meta[4,changeable]=0xffffffff/0xffffffff, match.parser_meta.outer_ip_fragmented[1,changeable]=0xff/0xff, match.outer.eth.type[2,changeable]=0xffff/0xffff, match.outer.eth.dst_mac[6,changeable]=0xffffffffffff/0xffffffff0000, match.outer.l3_type[4,specific]=0x01000000/0x01000000, match.outer.ip4.dst_ip[4,changeable]=0xffffffff/0xffffff80, match.outer.ip4.next_proto[1,changeable]=0xff/0xff, match.outer.l4_type_ext[4,specific]=0x01000000/0x01000000, match.outer.tcp.l4_port.src_port[2,changeable]=0xffff/0xffff, match.outer.tcp.l4_port.dst_port[2,changeable]=0xffff/0x8000, actions.meta.pkt_meta[4,changeable]=0xffffffff/0x00f0ffff
+esw=0xffff128ff048, group_id=0x00000000, priority=1, fwd.type=pipe, match.parser_meta.port_meta[4,changeable]=0xffffffff/0xffffffff, match.parser_meta.outer_ip_fragmented[1,changeable]=0xff/0xff, match.outer.eth.type[2,changeable]=0xffff/0xffff, match.outer.eth.dst_mac[6,changeable]=0xffffffffffff/0xffffffffffff, match.outer.l3_type[4,specific]=0x01000000/0x01000000, match.outer.ip4.dst_ip[4,changeable]=0xffffffff/0xffff0000, match.outer.ip4.next_proto[1,changeable]=0xff/0xff, match.outer.l4_type_ext[4,specific]=0x01000000/0x01000000, match.outer.tcp.l4_port.src_port[2,changeable]=0xffff/0x8000, match.outer.tcp.l4_port.dst_port[2,changeable]=0xffff/0xff00, actions.meta.pkt_meta[4,changeable]=0xffffffff/0x00f0ffff
+esw=0xffff128ff048, group_id=0x00000000, priority=1, fwd.type=pipe, match.parser_meta.port_meta[4,changeable]=0xffffffff/0xffffffff, match.tun.type[4,specific]=0x01000000/0x01000000, match.tun.vxlan_tun_id[4,changeable]=0xffffffff/0xffffff00, match.outer.eth.dst_mac[6,changeable]=0xffffffffffff/0xffffffffffff, match.outer.l3_type[4,specific]=0x01000000/0x01000000, match.outer.ip4.src_ip[4,changeable]=0xffffffff/0xffffffff, match.outer.ip4.dst_ip[4,changeable]=0xffffffff/0xffffffff, match.outer.ip4.dscp_ecn[1,changeable]=0xff/0xff, match.outer.ip4.next_proto[1,changeable]=0xff/0xff, actions.meta.u32[i][4,changeable]=0xffffffff/0xffffffff
+esw=0xffff128ff048, group_id=0x00000000, priority=1, fwd.type=pipe, match.parser_meta.port_meta[4,changeable]=0xffffffff/0xffffffff, match.parser_meta.outer_ip_fragmented[1,changeable]=0xff/0xff, match.outer.eth.type[2,changeable]=0xffff/0xffff, match.outer.eth.dst_mac[6,changeable]=0xffffffffffff/0xffffffffffff, match.outer.l3_type[4,specific]=0x01000000/0x01000000, match.outer.ip4.dst_ip[4,changeable]=0xffffffff/0xffffffff, match.outer.ip4.next_proto[1,changeable]=0xff/0xff, match.outer.l4_type_ext[4,specific]=0x03000000/0x03000000, match.outer.icmp.type[1,changeable]=0xff/0xfc, actions.meta.pkt_meta[4,changeable]=0xffffffff/0x00f0ffff
+esw=0xffff128ff048, group_id=0x00000000, priority=1, fwd.type=port, match.parser_meta.port_meta[4,changeable]=0xffffffff/0xffffffff, match.parser_meta.outer_ip_fragmented[1,changeable]=0xff/0xff, match.outer.eth.type[2,changeable]=0xffff/0xffff, match.outer.eth.dst_mac[6,changeable]=0xffffffffffff/0xffffffffffff, match.outer.eth.src_mac[6,changeable]=0xffffffffffff/0xffffffffffff, match.outer.l3_type[4,specific]=0x01000000/0x01000000, match.outer.ip4.src_ip[4,changeable]=0xffffffff/0xffffffff, match.outer.ip4.dst_ip[4,changeable]=0xffffffff/0xf8000000, match.outer.ip4.dscp_ecn[1,changeable]=0xff/0xff, match.outer.ip4.next_proto[1,changeable]=0xff/0xff, match.outer.ip4.ttl[1,changeable]=0xff/0xff, match.outer.l4_type_ext[4,specific]=0x02000000/0x02000000, match.outer.udp.l4_port.dst_port[2,changeable]=0xffff/0xffc0, actions.outer.eth.dst_mac[6,changeable]=0xffffffffffff/0xffffffffffff, actions.outer.eth.src_mac[6,changeable]=0xffffffffffff/0xffffffffffff, actions.outer.l3_type[4,specific]=0x01000000/0x01000000, actions.outer.ip4.src_ip[4,changeable]=0xffffffff/0xffffffff, actions.outer.ip4.ttl[1,changeable]=0xff/0xff, actions.encap_cfg.is_l2[1,specific]=0x01/0x01, actions.encap_type[4,specific]=0x02000000/0x02000000, actions.encap.outer.eth.type[2,specific]=0x0800/0xffff, actions.encap.outer.eth.dst_mac[6,changeable]=0xffffffffffff/0xffffffffffff, actions.encap.outer.eth.src_mac[6,changeable]=0xffffffffffff/0xffffffffffff, actions.encap.outer.l3_type[4,specific]=0x01000000/0x01000000, actions.encap.outer.ip4.src_ip[4,changeable]=0xffffffff/0xffffffff, actions.encap.outer.ip4.dst_ip[4,changeable]=0xffffffff/0xffffffff, actions.encap.outer.ip4.dscp_ecn[1,changeable]=0xff/0xff, actions.encap.outer.ip4.ttl[1,changeable]=0xff/0xff, actions.encap.outer.l4_type_ext[4,specific]=0x02000000/0x00000000, actions.encap.outer.udp.l4_port.src_port[2,changeable]=0xffff/0xffff, actions.encap.outer.udp.l4_port.dst_port[2,changeable]=0xffff/0xffff, actions.encap.tun.type[4,specific]=0x01000000/0x01000000, actions.encap.tun.vxlan_tun_id[4,changeable]=0xffffffff/0xffffffff
+esw=0xffff128ff048, group_id=0x00000000, priority=1, fwd.type=pipe, match.parser_meta.port_meta[4,changeable]=0xffffffff/0xffffffff, match.parser_meta.outer_ip_fragmented[1,changeable]=0xff/0xff, match.outer.eth.type[2,changeable]=0xffff/0xffff, match.outer.eth.dst_mac[6,changeable]=0xffffffffffff/0xffffffff0000, match.outer.l3_type[4,specific]=0x01000000/0x01000000, match.outer.ip4.next_proto[1,changeable]=0xff/0xff, match.outer.l4_type_ext[4,specific]=0x01000000/0x01000000, match.outer.tcp.l4_port.src_port[2,changeable]=0xffff/0xffff, match.outer.tcp.l4_port.dst_port[2,changeable]=0xffff/0xc000, actions.meta.pkt_meta[4,changeable]=0xffffffff/0x00f0ffff
+esw=0xffff128ff048, group_id=0x00000000, priority=1, fwd.type=pipe, match.parser_meta.port_meta[4,changeable]=0xffffffff/0xffffffff, match.parser_meta.outer_ip_fragmented[1,changeable]=0xff/0xff, match.outer.eth.type[2,changeable]=0xffff/0xffff, match.outer.eth.dst_mac[6,changeable]=0xffffffffffff/0xffffffff0000, match.outer.l3_type[4,specific]=0x01000000/0x01000000, match.outer.ip4.next_proto[1,changeable]=0xff/0xff, match.outer.l4_type_ext[4,specific]=0x01000000/0x01000000, match.outer.tcp.l4_port.src_port[2,changeable]=0xffff/0xffff, match.outer.tcp.l4_port.dst_port[2,changeable]=0xffff/0xe000, actions.meta.pkt_meta[4,changeable]=0xffffffff/0x00f0ffff
+esw=0xffff128ff048, group_id=0x00000000, priority=1, fwd.type=pipe, match.parser_meta.port_meta[4,changeable]=0xffffffff/0xffffffff, match.parser_meta.outer_ip_fragmented[1,changeable]=0xff/0xff, match.outer.eth.type[2,changeable]=0xffff/0xffff, match.outer.eth.dst_mac[6,changeable]=0xffffffffffff/0xffffffff0000, match.outer.l3_type[4,specific]=0x01000000/0x01000000, match.outer.ip4.next_proto[1,changeable]=0xff/0xff, match.outer.l4_type_ext[4,specific]=0x01000000/0x01000000, match.outer.tcp.l4_port.src_port[2,changeable]=0xffff/0xffff, match.outer.tcp.l4_port.dst_port[2,changeable]=0xffff/0xfc00, actions.meta.pkt_meta[4,changeable]=0xffffffff/0x00f0ffff
+esw=0xffff128ff048, group_id=0x00000000, priority=1, fwd.type=pipe, match.parser_meta.port_meta[4,changeable]=0xffffffff/0xffffffff, match.parser_meta.outer_ip_fragmented[1,changeable]=0xff/0xff, match.outer.eth.type[2,changeable]=0xffff/0xffff, match.outer.eth.dst_mac[6,changeable]=0xffffffffffff/0xffffffff0000, match.outer.l3_type[4,specific]=0x01000000/0x01000000, match.outer.ip4.next_proto[1,changeable]=0xff/0xff, match.outer.l4_type_ext[4,specific]=0x01000000/0x01000000, match.outer.tcp.l4_port.src_port[2,changeable]=0xffff/0xffff, match.outer.tcp.l4_port.dst_port[2,changeable]=0xffff/0xf800, actions.meta.pkt_meta[4,changeable]=0xffffffff/0x00f0ffff
+esw=0xffff128ff048, group_id=0x00000000, priority=1, fwd.type=pipe, match.parser_meta.port_meta[4,changeable]=0xffffffff/0xffffffff, match.parser_meta.outer_ip_fragmented[1,changeable]=0xff/0xff, match.outer.eth.type[2,changeable]=0xffff/0xffff, match.outer.eth.dst_mac[6,changeable]=0xffffffffffff/0xffffffff0000, match.outer.l3_type[4,specific]=0x01000000/0x01000000, match.outer.ip4.next_proto[1,changeable]=0xff/0xff, match.outer.l4_type_ext[4,specific]=0x01000000/0x01000000, match.outer.tcp.l4_port.src_port[2,changeable]=0xffff/0xffff, match.outer.tcp.l4_port.dst_port[2,changeable]=0xffff/0xf000, actions.meta.pkt_meta[4,changeable]=0xffffffff/0x00f0ffff
+esw=0xffff128ff048, group_id=0x00000000, priority=1, fwd.type=pipe, match.parser_meta.port_meta[4,changeable]=0xffffffff/0xffffffff, match.parser_meta.outer_ip_fragmented[1,changeable]=0xff/0xff, match.outer.eth.type[2,changeable]=0xffff/0xffff, match.outer.eth.dst_mac[6,changeable]=0xffffffffffff/0xffffffffffff, match.outer.l3_type[4,specific]=0x01000000/0x01000000, match.outer.ip4.dst_ip[4,changeable]=0xffffffff/0xffff0000, match.outer.ip4.next_proto[1,changeable]=0xff/0xff, match.outer.l4_type_ext[4,specific]=0x01000000/0x01000000, match.outer.tcp.l4_port.src_port[2,changeable]=0xffff/0xc000, match.outer.tcp.l4_port.dst_port[2,changeable]=0xffff/0xff00, actions.meta.pkt_meta[4,changeable]=0xffffffff/0x00f0ffff
+esw=0xffff128ff048, group_id=0x00000000, priority=1, fwd.type=pipe, match.parser_meta.port_meta[4,changeable]=0xffffffff/0xffffffff, match.parser_meta.outer_ip_fragmented[1,changeable]=0xff/0xff, match.outer.eth.type[2,changeable]=0xffff/0xffff, match.outer.eth.dst_mac[6,changeable]=0xffffffffffff/0xffffffffffff, match.outer.l3_type[4,specific]=0x01000000/0x01000000, match.outer.ip4.dst_ip[4,changeable]=0xffffffff/0xffff0000, match.outer.ip4.next_proto[1,changeable]=0xff/0xff, match.outer.l4_type_ext[4,specific]=0x01000000/0x01000000, match.outer.tcp.l4_port.src_port[2,changeable]=0xffff/0xe000, match.outer.tcp.l4_port.dst_port[2,changeable]=0xffff/0xff00, actions.meta.pkt_meta[4,changeable]=0xffffffff/0x00f0ffff
+esw=0xffff128ff048, group_id=0x00000000, priority=1, fwd.type=port, match.parser_meta.port_meta[4,changeable]=0xffffffff/0xffffffff, match.parser_meta.outer_ip_fragmented[1,changeable]=0xff/0xff, match.outer.eth.type[2,changeable]=0xffff/0xffff, match.outer.eth.dst_mac[6,changeable]=0xffffffffffff/0xffffffffffff, match.outer.eth.src_mac[6,changeable]=0xffffffffffff/0xffffffffffff, match.outer.l3_type[4,specific]=0x01000000/0x01000000, match.outer.ip4.src_ip[4,changeable]=0xffffffff/0xffffffff, match.outer.ip4.dst_ip[4,changeable]=0xffffffff/0xf8000000, match.outer.ip4.dscp_ecn[1,changeable]=0xff/0xff, match.outer.ip4.next_proto[1,changeable]=0xff/0xff, match.outer.ip4.ttl[1,changeable]=0xff/0xff, match.outer.l4_type_ext[4,specific]=0x02000000/0x02000000, match.outer.udp.l4_port.dst_port[2,changeable]=0xffff/0xffe0, actions.outer.eth.dst_mac[6,changeable]=0xffffffffffff/0xffffffffffff, actions.outer.eth.src_mac[6,changeable]=0xffffffffffff/0xffffffffffff, actions.outer.l3_type[4,specific]=0x01000000/0x01000000, actions.outer.ip4.src_ip[4,changeable]=0xffffffff/0xffffffff, actions.outer.ip4.ttl[1,changeable]=0xff/0xff, actions.encap_cfg.is_l2[1,specific]=0x01/0x01, actions.encap_type[4,specific]=0x02000000/0x02000000, actions.encap.outer.eth.type[2,specific]=0x0800/0xffff, actions.encap.outer.eth.dst_mac[6,changeable]=0xffffffffffff/0xffffffffffff, actions.encap.outer.eth.src_mac[6,changeable]=0xffffffffffff/0xffffffffffff, actions.encap.outer.l3_type[4,specific]=0x01000000/0x01000000, actions.encap.outer.ip4.src_ip[4,changeable]=0xffffffff/0xffffffff, actions.encap.outer.ip4.dst_ip[4,changeable]=0xffffffff/0xffffffff, actions.encap.outer.ip4.dscp_ecn[1,changeable]=0xff/0xff, actions.encap.outer.ip4.ttl[1,changeable]=0xff/0xff, actions.encap.outer.l4_type_ext[4,specific]=0x02000000/0x00000000, actions.encap.outer.udp.l4_port.src_port[2,changeable]=0xffff/0xffff, actions.encap.outer.udp.l4_port.dst_port[2,changeable]=0xffff/0xffff, actions.encap.tun.type[4,specific]=0x01000000/0x01000000, actions.encap.tun.vxlan_tun_id[4,changeable]=0xffffffff/0xffffffff
+esw=0xffff128ff048, group_id=0x00000000, priority=2, fwd.type=port, match.parser_meta.port_meta[4,changeable]=0xffffffff/0xffffffff, match.parser_meta.outer_ip_fragmented[1,changeable]=0xff/0xff, match.outer.eth.type[2,changeable]=0xffff/0xffff, match.outer.l3_type[4,specific]=0x02000000/0x02000000, empty_actions_mask
+esw=0xffff128ff048, group_id=0x00000000, priority=2, fwd.type=pipe, match.parser_meta.port_meta[4,changeable]=0xffffffff/0xffffffff, match.parser_meta.outer_ip_fragmented[1,changeable]=0xff/0xff, match.outer.eth.type[2,changeable]=0xffff/0xffff, match.outer.eth.dst_mac[6,changeable]=0xffffffffffff/0xffffffff0000, match.outer.l3_type[4,specific]=0x02000000/0x02000000, match.outer.ip6.next_proto[1,changeable]=0xff/0xff, match.outer.l4_type_ext[4,specific]=0x04000000/0x04000000, match.outer.icmp.type[1,changeable]=0xff/0xff, actions.meta.pkt_meta[4,changeable]=0xffffffff/0x00f0ffff
+esw=0xffff128ff048, group_id=0x00000000, priority=2, fwd.type=pipe, match.parser_meta.port_meta[4,changeable]=0xffffffff/0xffffffff, match.parser_meta.outer_ip_fragmented[1,changeable]=0xff/0xff, match.outer.eth.type[2,changeable]=0xffff/0xffff, match.outer.eth.dst_mac[6,changeable]=0xffffffffffff/0xffffffff0000, match.outer.l3_type[4,specific]=0x02000000/0x02000000, match.outer.ip6.dst_ip[16,changeable]=0xffffffffffffffffffffffffffffffff/0xffffffffffff00000000000000000000, match.outer.ip6.next_proto[1,changeable]=0xff/0xff, match.outer.l4_type_ext[4,specific]=0x04000000/0x04000000, match.outer.icmp.type[1,changeable]=0xff/0xff, actions.meta.pkt_meta[4,changeable]=0xffffffff/0x00f0ffff
+esw=0xffff128ff048, group_id=0x00000000, priority=2, fwd.type=pipe, match.parser_meta.port_meta[4,changeable]=0xffffffff/0xffffffff, match.parser_meta.outer_ip_fragmented[1,changeable]=0xff/0xff, match.outer.eth.type[2,changeable]=0xffff/0xffff, match.outer.eth.dst_mac[6,changeable]=0xffffffffffff/0xffffffff0000, match.outer.l3_type[4,specific]=0x02000000/0x02000000, match.outer.ip6.next_proto[1,changeable]=0xff/0xff, match.outer.l4_type_ext[4,specific]=0x01000000/0x01000000, match.outer.tcp.l4_port.src_port[2,changeable]=0xffff/0xffff, match.outer.tcp.l4_port.dst_port[2,changeable]=0xffff/0x8000, actions.meta.pkt_meta[4,changeable]=0xffffffff/0x00f0ffff
+esw=0xffff128ff048, group_id=0x00000000, priority=2, fwd.type=pipe, match.parser_meta.port_meta[4,changeable]=0xffffffff/0xffffffff, match.parser_meta.outer_ip_fragmented[1,changeable]=0xff/0xff, match.outer.eth.type[2,changeable]=0xffff/0xffff, match.outer.eth.dst_mac[6,changeable]=0xffffffffffff/0xffffffff0000, match.outer.l3_type[4,specific]=0x02000000/0x02000000, actions.meta.pkt_meta[4,changeable]=0xffffffff/0x00f0ffff
+esw=0xffff128ff048, group_id=0x00000000, priority=2, fwd.type=pipe, match.parser_meta.port_meta[4,changeable]=0xffffffff/0xffffffff, match.parser_meta.outer_ip_fragmented[1,changeable]=0xff/0xff, match.outer.eth.type[2,changeable]=0xffff/0xffff, match.outer.eth.dst_mac[6,changeable]=0xffffffffffff/0xffffff000000, match.outer.l3_type[4,specific]=0x02000000/0x02000000, actions.meta.pkt_meta[4,changeable]=0xffffffff/0x00f0ffff
+esw=0xffff128ff048, group_id=0x00000000, priority=2, fwd.type=pipe, match.parser_meta.port_meta[4,changeable]=0xffffffff/0xffffffff, match.parser_meta.outer_ip_fragmented[1,changeable]=0xff/0xff, match.outer.eth.type[2,changeable]=0xffff/0xffff, match.outer.eth.dst_mac[6,changeable]=0xffffffffffff/0xffffffff0000, match.outer.l3_type[4,specific]=0x02000000/0x02000000, match.outer.ip6.dst_ip[16,changeable]=0xffffffffffffffffffffffffffffffff/0xffffffffffff00000000000000000000, match.outer.ip6.next_proto[1,changeable]=0xff/0xff, match.outer.l4_type_ext[4,specific]=0x01000000/0x01000000, match.outer.tcp.l4_port.src_port[2,changeable]=0xffff/0xffff, match.outer.tcp.l4_port.dst_port[2,changeable]=0xffff/0x8000, actions.meta.pkt_meta[4,changeable]=0xffffffff/0x00f0ffff
+esw=0xffff128ff048, group_id=0x00000000, priority=3, fwd.type=port, match.parser_meta.port_meta[4,changeable]=0xffffffff/0xffffffff, match.outer.eth.type[2,changeable]=0xffff/0xffff, empty_actions_mask
+esw=0xffff128ff048, group_id=0x00000000, priority=3, fwd.type=pipe, match.parser_meta.port_meta[4,changeable]=0xffffffff/0xffffffff, match.outer.eth.type[2,changeable]=0xffff/0xffff, actions.meta.pkt_meta[4,changeable]=0xffffffff/0x00f0ffff
+esw=0xffff128ff048, group_id=0x00000000, priority=4, fwd.type=pipe, empty_match, empty_actions_mask
+esw_mgr_port_id=0, group_id=0xff000000 (post-meter)
+esw=0xffff128ff048, group_id=0xff000000 (post-meter), priority=1, fwd.type=port, match.meta.pkt_meta[4,changeable]=0xffffffff/0x00f0ffff, match.parser_meta.meter_color[1,changeable]=0xff/0xff, actions.meta.pkt_meta[4,changeable]=0xffffffff/0x00f0ffff
+esw=0xffff128ff048, group_id=0xff000000 (post-meter), priority=2, fwd.type=drop, match.meta.pkt_meta[4,changeable]=0xffffffff/0x00f0ffff, empty_actions_mask
+esw=0xffff128ff048, group_id=0xff000000 (post-meter), priority=4, fwd.type=pipe, empty_match, empty_actions_mask
+esw_mgr_port_id=0, group_id=0xfb000000 (post-hash)
+esw=0xffff128ff048, group_id=0xfb000000 (post-hash), priority=4, fwd.type=pipe, empty_match, empty_actions_mask
+esw_mgr_port_id=0, group_id=0xfa000000 (split-post-prefix)
+esw=0xffff128ff048, group_id=0xfa000000 (split-post-prefix), priority=1, fwd.type=pipe, match.meta.u32[i][4,changeable]=0xffffffff/0xffffffff, match.parser_meta.port_meta[4,changeable]=0xffffffff/0xffffffff, match.parser_meta.inner_ip_fragmented[1,changeable]=0xff/0xff, match.tun.type[4,specific]=0x01000000/0x01000000, match.inner.eth.type[2,changeable]=0xffff/0xffff, match.inner.eth.dst_mac[6,changeable]=0xffffffffffff/0xffffffffffff, match.inner.l3_type[4,specific]=0x01000000/0x01000000, match.inner.ip4.dst_ip[4,changeable]=0xffffffff/0xfffffff8, match.inner.ip4.dscp_ecn[1,changeable]=0xff/0xff, match.inner.ip4.next_proto[1,changeable]=0xff/0xff, match.inner.l4_type_ext[4,specific]=0x03000000/0x03000000, match.inner.icmp.type[1,changeable]=0xff/0xfc, actions.meta.pkt_meta[4,changeable]=0xffffffff/0x00f0ffff
+esw=0xffff128ff048, group_id=0xfa000000 (split-post-prefix), priority=1, fwd.type=port, match.meta.u32[i][4,changeable]=0xffffffff/0xffffffff, match.parser_meta.port_meta[4,changeable]=0xffffffff/0xffffffff, match.parser_meta.inner_ip_fragmented[1,changeable]=0xff/0xff, match.tun.type[4,specific]=0x01000000/0x01000000, match.inner.eth.type[2,changeable]=0xffff/0xffff, match.inner.eth.dst_mac[6,changeable]=0xffffffffffff/0xffffffffffff, match.inner.eth.src_mac[6,changeable]=0xffffffffffff/0xffffffffffff, match.inner.l3_type[4,specific]=0x01000000/0x01000000, match.inner.ip4.dst_ip[4,changeable]=0xffffffff/0xffffffff, match.inner.ip4.next_proto[1,changeable]=0xff/0xff, match.inner.ip4.ttl[1,changeable]=0xff/0xff, match.inner.l4_type_ext[4,specific]=0x02000000/0x02000000, match.inner.udp.l4_port.dst_port[2,changeable]=0xffff/0x8000, actions.outer.eth.dst_mac[6,changeable]=0xffffffffffff/0xffffffffffff, actions.outer.eth.src_mac[6,changeable]=0xffffffffffff/0xffffffffffff, actions.outer.l3_type[4,specific]=0x01000000/0x01000000, actions.outer.ip4.dst_ip[4,changeable]=0xffffffff/0xffffffff, actions.outer.ip4.ttl[1,changeable]=0xff/0xff, actions.decap_type[4,specific]=0x02000000/0x02000000, actions.decap_cfg.is_l2[1,specific]=0x01/0x01
+esw=0xffff128ff048, group_id=0xfa000000 (split-post-prefix), priority=1, fwd.type=port, match.meta.u32[i][4,changeable]=0xffffffff/0xffffffff, match.parser_meta.port_meta[4,changeable]=0xffffffff/0xffffffff, match.parser_meta.inner_ip_fragmented[1,changeable]=0xff/0xff, match.tun.type[4,specific]=0x01000000/0x01000000, match.inner.eth.type[2,changeable]=0xffff/0xffff, match.inner.eth.dst_mac[6,changeable]=0xffffffffffff/0xffffffffffff, match.inner.eth.src_mac[6,changeable]=0xffffffffffff/0xffffffffffff, match.inner.l3_type[4,specific]=0x01000000/0x01000000, match.inner.ip4.dst_ip[4,changeable]=0xffffffff/0xffffffff, match.inner.ip4.next_proto[1,changeable]=0xff/0xff, match.inner.ip4.ttl[1,changeable]=0xff/0xff, match.inner.l4_type_ext[4,specific]=0x02000000/0x02000000, match.inner.udp.l4_port.dst_port[2,changeable]=0xffff/0xc000, actions.outer.eth.dst_mac[6,changeable]=0xffffffffffff/0xffffffffffff, actions.outer.eth.src_mac[6,changeable]=0xffffffffffff/0xffffffffffff, actions.outer.l3_type[4,specific]=0x01000000/0x01000000, actions.outer.ip4.dst_ip[4,changeable]=0xffffffff/0xffffffff, actions.outer.ip4.ttl[1,changeable]=0xff/0xff, actions.decap_type[4,specific]=0x02000000/0x02000000, actions.decap_cfg.is_l2[1,specific]=0x01/0x01
+esw=0xffff128ff048, group_id=0xfa000000 (split-post-prefix), priority=1, fwd.type=port, match.meta.u32[i][4,changeable]=0xffffffff/0xffffffff, match.parser_meta.port_meta[4,changeable]=0xffffffff/0xffffffff, match.parser_meta.inner_ip_fragmented[1,changeable]=0xff/0xff, match.tun.type[4,specific]=0x01000000/0x01000000, match.inner.eth.type[2,changeable]=0xffff/0xffff, match.inner.eth.dst_mac[6,changeable]=0xffffffffffff/0xffffffffffff, match.inner.eth.src_mac[6,changeable]=0xffffffffffff/0xffffffffffff, match.inner.l3_type[4,specific]=0x01000000/0x01000000, match.inner.ip4.dst_ip[4,changeable]=0xffffffff/0xffffffff, match.inner.ip4.next_proto[1,changeable]=0xff/0xff, match.inner.ip4.ttl[1,changeable]=0xff/0xff, match.inner.l4_type_ext[4,specific]=0x02000000/0x02000000, match.inner.udp.l4_port.dst_port[2,changeable]=0xffff/0xe000, actions.outer.eth.dst_mac[6,changeable]=0xffffffffffff/0xffffffffffff, actions.outer.eth.src_mac[6,changeable]=0xffffffffffff/0xffffffffffff, actions.outer.l3_type[4,specific]=0x01000000/0x01000000, actions.outer.ip4.dst_ip[4,changeable]=0xffffffff/0xffffffff, actions.outer.ip4.ttl[1,changeable]=0xff/0xff, actions.decap_type[4,specific]=0x02000000/0x02000000, actions.decap_cfg.is_l2[1,specific]=0x01/0x01
+esw=0xffff128ff048, group_id=0xfa000000 (split-post-prefix), priority=1, fwd.type=port, match.meta.u32[i][4,changeable]=0xffffffff/0xffffffff, match.parser_meta.port_meta[4,changeable]=0xffffffff/0xffffffff, match.parser_meta.inner_ip_fragmented[1,changeable]=0xff/0xff, match.tun.type[4,specific]=0x01000000/0x01000000, match.inner.eth.type[2,changeable]=0xffff/0xffff, match.inner.eth.dst_mac[6,changeable]=0xffffffffffff/0xffffffffffff, match.inner.eth.src_mac[6,changeable]=0xffffffffffff/0xffffffffffff, match.inner.l3_type[4,specific]=0x01000000/0x01000000, match.inner.ip4.dst_ip[4,changeable]=0xffffffff/0xffffffff, match.inner.ip4.next_proto[1,changeable]=0xff/0xff, match.inner.ip4.ttl[1,changeable]=0xff/0xff, match.inner.l4_type_ext[4,specific]=0x02000000/0x02000000, match.inner.udp.l4_port.dst_port[2,changeable]=0xffff/0xffe0, actions.outer.eth.dst_mac[6,changeable]=0xffffffffffff/0xffffffffffff, actions.outer.eth.src_mac[6,changeable]=0xffffffffffff/0xffffffffffff, actions.outer.l3_type[4,specific]=0x01000000/0x01000000, actions.outer.ip4.dst_ip[4,changeable]=0xffffffff/0xffffffff, actions.outer.ip4.ttl[1,changeable]=0xff/0xff, actions.decap_type[4,specific]=0x02000000/0x02000000, actions.decap_cfg.is_l2[1,specific]=0x01/0x01
+esw=0xffff128ff048, group_id=0xfa000000 (split-post-prefix), priority=4, fwd.type=pipe, empty_match, empty_actions_mask
+esw_mgr_port_id=0, group_id=0xfc00012d (ct-301)
+esw=0xffff128ff048, group_id=0xfc00012d (ct-301), priority=1, fwd.type=pipe, match.meta.u32[i][4,changeable]=0xffffffff/0xffff0020, empty_actions_mask
+esw=0xffff128ff048, group_id=0xfc00012d (ct-301), priority=2, fwd.type=pipe, match.outer.l3_type[4,specific]=0x01000000/0x01000000, match.outer.l4_type_ext[4,specific]=0x02000000/0x02000000, actions.meta.u32[i][4,changeable]=0xffffffff/0xffff0000
+esw=0xffff128ff048, group_id=0xfc00012d (ct-301), priority=2, fwd.type=pipe, match.outer.l3_type[4,specific]=0x01000000/0x01000000, match.outer.l4_type_ext[4,specific]=0x01000000/0x01000000, match.outer.tcp.flags[1,changeable]=0xff/0x07, actions.meta.u32[i][4,changeable]=0xffffffff/0xffff0000
+esw=0xffff128ff048, group_id=0xfc00012d (ct-301), priority=4, fwd.type=pipe, empty_match, empty_actions_mask
+esw_mgr_port_id=0, group_id=0xfd000000 (post-ct)
+esw=0xffff128ff048, group_id=0xfd000000 (post-ct), priority=4, fwd.type=pipe, empty_match, empty_actions_mask
+esw_mgr_port_id=0, group_id=0xfc10012d (ct-nat-301)
+esw=0xffff128ff048, group_id=0xfc10012d (ct-nat-301), priority=1, fwd.type=pipe, match.meta.u32[i][4,changeable]=0xffffffff/0xffff00e0, empty_actions_mask
+esw=0xffff128ff048, group_id=0xfc10012d (ct-nat-301), priority=2, fwd.type=pipe, match.outer.l3_type[4,specific]=0x01000000/0x01000000, match.outer.l4_type_ext[4,specific]=0x02000000/0x02000000, actions.meta.u32[i][4,changeable]=0xffffffff/0xffff0000
+esw=0xffff128ff048, group_id=0xfc10012d (ct-nat-301), priority=2, fwd.type=pipe, match.outer.l3_type[4,specific]=0x01000000/0x01000000, match.outer.l4_type_ext[4,specific]=0x01000000/0x01000000, match.outer.tcp.flags[1,changeable]=0xff/0x07, actions.meta.u32[i][4,changeable]=0xffffffff/0xffff0000
+esw=0xffff128ff048, group_id=0xfc10012d (ct-nat-301), priority=4, fwd.type=pipe, empty_match, empty_actions_mask
+esw_mgr_port_id=0, group_id=0xf3000000 (miss)`,
+			metric: OvsMetric{
+				DocaPipegroupMainEntries:          26,
+				DocaPipegroupSamplePostmirrorEntries: 2,
+				DocaPipegroupSplitPostprefixEntries:  6,
+				DocaPipegroupPosthashEntries:         1,
+				DocaPipegroupPostctEntries:           1,
+				DocaPipegroupPostmeterEntries:        3,
+				DocaPipegroupCtEntries:               4,
+				DocaPipegroupCtnatEntries:            4,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var ovsMetric OvsMetric
+			parseDocaPipegroupEntries(&ovsMetric, tt.output)
+
+			diff := cmp.Diff(ovsMetric, tt.metric)
+			if diff != "" {
+				t.Errorf("Structs are different:\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Add DOCA pipe group entry metrics

This PR adds metrics to track the number of entries in each DOCA pipe group.

### Changes

Added 8 new gauge metrics:
- `ovsdp_doca_pipegroup_main_entries` - Main table (group_id=0x00000000)
- `ovsdp_doca_pipegroup_sample_postmirror_entries` - Sample-post-mirror table (0xf2000000)
- `ovsdp_doca_pipegroup_split_postprefix_entries` - Split-post-prefix table (0xfa000000)
- `ovsdp_doca_pipegroup_posthash_entries` - Post-hash table (0xfb000000)
- `ovsdp_doca_pipegroup_postct_entries` - Post-CT table (0xfd000000)
- `ovsdp_doca_pipegroup_postmeter_entries` - Post-meter table (0xff000000)
- `ovsdp_doca_pipegroup_ct_entries` - Aggregated CT entries across all zones (0xfc0*)
- `ovsdp_doca_pipegroup_ctnat_entries` - Aggregated CT-NAT entries across all zones (0xfc1*)

### Implementation

- Parses output from `ovs-appctl doca-pipe-group/dump`
- Counts entries by matching lines starting with `esw=` and extracting group_id
- Uses exact matching for infrastructure tables and prefix matching for dynamic CT/CTNAT zones
- Returns -1 on error, following existing metric conventions