### PR TITLE
feat: Added drop_invalid_mark

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -65,6 +65,7 @@ type ovsDPCollector struct {
 	datapathDropTunnelTsoRecircMetric *prometheus.Desc
 	datapathDropInvalidBondMetric     *prometheus.Desc
 	datapathDropHwMissRecoverMetric   *prometheus.Desc
+	datapathDropInvalidMarkMetric     *prometheus.Desc
 	// DOCA
 	ovsDocaNoMarkMetric              *prometheus.Desc
 	ovsDocaInvalidClassifyPortMetric *prometheus.Desc
@@ -307,6 +308,10 @@ func newOvsDPCollector() *ovsDPCollector {
 			"Drop packet due to hardware miss recovery failure",
 			nil, nil,
 		),
+		datapathDropInvalidMarkMetric: prometheus.NewDesc("ovsdp_datapath_drop_invalid_mark",
+			"Drop packet due to stale or invalid flow mark",
+			nil, nil,
+		),
 		// DOCA
 		ovsDocaNoMarkMetric: prometheus.NewDesc("ovsdp_ovs_doca_no_mark",
 			"Number of packets dropped due to missing mark in OVS-DOCA",
@@ -421,6 +426,7 @@ func (collector *ovsDPCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- collector.datapathDropTunnelTsoRecircMetric
 	ch <- collector.datapathDropInvalidBondMetric
 	ch <- collector.datapathDropHwMissRecoverMetric
+	ch <- collector.datapathDropInvalidMarkMetric
 	// DOCA
 	ch <- collector.ovsDocaNoMarkMetric
 	ch <- collector.ovsDocaInvalidClassifyPortMetric
@@ -606,6 +612,9 @@ func (collector *ovsDPCollector) Collect(ch chan<- prometheus.Metric) {
 	}
 	if isValidMetric(ovsMetric.DatapathDropHwMissRecover) {
 		ch <- prometheus.MustNewConstMetric(collector.datapathDropHwMissRecoverMetric, prometheus.CounterValue, float64(ovsMetric.DatapathDropHwMissRecover))
+	}
+	if isValidMetric(ovsMetric.DatapathDropInvalidMark) {
+		ch <- prometheus.MustNewConstMetric(collector.datapathDropInvalidMarkMetric, prometheus.CounterValue, float64(ovsMetric.DatapathDropInvalidMark))
 	}
 	// DOCA
 	if isValidMetric(ovsMetric.OvsDocaNoMark) {

--- a/metric.go
+++ b/metric.go
@@ -71,6 +71,7 @@ type OvsMetric struct {
 	DatapathDropTunnelTsoRecirc float64
 	DatapathDropInvalidBond     float64
 	DatapathDropHwMissRecover   float64
+	DatapathDropInvalidMark     float64
 	// DOCA
 	OvsDocaNoMark              float64
 	OvsDocaInvalidClassifyPort float64
@@ -575,6 +576,17 @@ func parseCoverageDropReasons(metrics *OvsMetric, coverageStats string) {
 		v, err := strconv.ParseFloat(datapathDropHwMissRecoverMatch[1], 64)
 		if err == nil {
 			metrics.DatapathDropHwMissRecover = v
+		}
+	}
+
+	// Datapath drop invalid mark
+	datapathDropInvalidMarkRegexp := regexp.MustCompile(`(?m)^[ \t]*datapath_drop_invalid_mark.*total:\s*(\d+)`)
+	datapathDropInvalidMarkMatch := datapathDropInvalidMarkRegexp.FindStringSubmatch(coverageStats)
+	metrics.DatapathDropInvalidMark = -1
+	if len(datapathDropInvalidMarkMatch) > 1 {
+		v, err := strconv.ParseFloat(datapathDropInvalidMarkMatch[1], 64)
+		if err == nil {
+			metrics.DatapathDropInvalidMark = v
 		}
 	}
 

--- a/metric_test.go
+++ b/metric_test.go
@@ -95,11 +95,12 @@ netdev_soft_seg_drops   0.0/sec     0.000/sec        0.0000/sec   total: 32
 datapath_drop_tunnel_tso_recirc   0.0/sec     0.000/sec        0.0000/sec   total: 33
 datapath_drop_invalid_bond   0.0/sec     0.000/sec        0.0000/sec   total: 34
 datapath_drop_hw_miss_recover   0.0/sec     0.000/sec        0.0000/sec   total: 35
-upcall_flow_limit_grew       0.0/sec     0.000/sec        0.0000/sec   total: 36
-upcall_flow_limit_hit        0.0/sec     0.000/sec        0.0000/sec   total: 37
-upcall_flow_limit_kill       0.0/sec     0.000/sec        0.0000/sec   total: 38
-upcall_flow_limit_reduced    0.0/sec     0.000/sec        0.0000/sec   total: 39
-upcall_flow_limit_scaled     0.0/sec     0.000/sec        0.0000/sec   total: 40`,
+datapath_drop_invalid_mark   0.0/sec     0.000/sec        0.0000/sec   total: 36
+upcall_flow_limit_grew       0.0/sec     0.000/sec        0.0000/sec   total: 37
+upcall_flow_limit_hit        0.0/sec     0.000/sec        0.0000/sec   total: 38
+upcall_flow_limit_kill       0.0/sec     0.000/sec        0.0000/sec   total: 39
+upcall_flow_limit_reduced    0.0/sec     0.000/sec        0.0000/sec   total: 40
+upcall_flow_limit_scaled     0.0/sec     0.000/sec        0.0000/sec   total: 41`,
 			metric: OvsMetric{
 				// Drop reasons
 				UpcallDrops:                      5,
@@ -134,12 +135,13 @@ upcall_flow_limit_scaled     0.0/sec     0.000/sec        0.0000/sec   total: 40
 				DatapathDropTunnelTsoRecirc: 33,
 				DatapathDropInvalidBond:     34,
 				DatapathDropHwMissRecover:   35,
+				DatapathDropInvalidMark:     36,
 				// Upcall Flow Limit
-				UpcallFlowLimitGrew:    36,
-				UpcallFlowLimitHit:     37,
-				UpcallFlowLimitKill:    38,
-				UpcallFlowLimitReduced: 39,
-				UpcallFlowLimitScaled:  40,
+				UpcallFlowLimitGrew:    37,
+				UpcallFlowLimitHit:     38,
+				UpcallFlowLimitKill:    39,
+				UpcallFlowLimitReduced: 40,
+				UpcallFlowLimitScaled:  41,
 			},
 		},
 	}


### PR DESCRIPTION
## Summary
Adds the ovsdp_datapath_drop_invalid_mark counter, which tracks packets
dropped due to a stale or invalid flow mark in OVS-DOCA. The coverage
counter is datapath_drop_invalid_mark (no doca_ prefix).

## Test plan:
Building:
```
CW-FX2KT9MM2L-L ☸︎ us-lab-01b (mgmt) ovsdp-exporter  on  HEAD (9d1693f) [?] via  v1.25.3
17:33:36 »  GOOS=linux GOARCH=arm64 go build -o ovsdp-exporter-arm64 .

17:35:13 »  scp -F ~/.ssh/dpr-config -i ~/.ssh/vault_ed25519 ./ovsdp-exporter-arm64 acc@10.196.128.75:/tmp/ovsdp-exporter

```



On DPU:
```
acc@dpu-dhc-r012-node-11-us-lab-01b [VRF: mgmt] 10.196.128.75 [dpu-initialized]:~$ sudo /tmp/ovsdp-exporter -metrics.host :19000
Starting server listening: :19000
```

On DPU:
```
acc@dpu-dhc-r012-node-11-us-lab-01b [VRF: mgmt] 10.196.128.75 [dpu-initialized]:~$ curl localhost:19000/metrics  2>/dev/null | grep invalid_mark
# HELP ovsdp_datapath_drop_invalid_mark Drop packet due to stale or invalid flow mark
# TYPE ovsdp_datapath_drop_invalid_mark counter
ovsdp_datapath_drop_invalid_mark 96
```